### PR TITLE
Fix PBs referencing constrained bones not working

### DIFF
--- a/Packages/net.fushizen.modular-avatar/Editor/MergeArmatureHook.cs
+++ b/Packages/net.fushizen.modular-avatar/Editor/MergeArmatureHook.cs
@@ -286,20 +286,7 @@ namespace net.fushizen.modular_avatar.core.editor
             mergedSrcBone.transform.localPosition = src.transform.localPosition;
             mergedSrcBone.transform.localRotation = src.transform.localRotation;
             mergedSrcBone.transform.localScale = src.transform.localScale;
-
-            if (zipMerge)
-            {
-                BoneDatabase.AddMergedBone(mergedSrcBone.transform);
-                var srcPath = RuntimeUtil.AvatarRootPath(src);
-                PathMappings.Remap(srcPath, new PathMappings.MappingEntry()
-                {
-                    transformPath = RuntimeUtil.AvatarRootPath(newParent),
-                    path = srcPath
-                });
-            }
-
             mergedSrcBone.transform.SetParent(newParent.transform, true);
-            BoneRemappings[src.transform] = mergedSrcBone.transform;
 
             bool retain = HasAdditionalComponents(src, out var constraintType);
             if (constraintType != null)
@@ -330,6 +317,19 @@ namespace net.fushizen.modular_avatar.core.editor
                     $"with constraintType {constraintType} and constraint {src.GetComponent<IConstraint>()}");
                 return true;
             }
+
+            if (zipMerge)
+            {
+                BoneDatabase.AddMergedBone(mergedSrcBone.transform);
+                var srcPath = RuntimeUtil.AvatarRootPath(src);
+                PathMappings.Remap(srcPath, new PathMappings.MappingEntry()
+                {
+                    transformPath = RuntimeUtil.AvatarRootPath(newParent),
+                    path = srcPath
+                });
+            }
+
+            BoneRemappings[src.transform] = mergedSrcBone.transform;
 
             List<Transform> children = new List<Transform>();
             foreach (Transform child in src.transform)


### PR DESCRIPTION
When a PB references a bone controlled by a constraint, the subtree rooted at that bone will be present only on the original armature tree, and not in the avatar's main armature tree (except for a stub object that may or may not be used for a constraint reference).

Previously, there was a bug in which PBs would reference the stub object, rather than the object that contains the bones that need to be animated by PBs. This commit changes the order of processing so bones are only registered for rewriting PB referenced if their subtrees will be transferred to the main armature.