### PR TITLE
Added support for closing AvMenuTreeViewWindow automatically when it loses focus.

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvMenuTreeView.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvMenuTreeView.cs
@@ -30,6 +30,10 @@ namespace nadena.dev.modular_avatar.core.editor
             _treeView.OnDoubleclickSelect = Close;
         }
 
+        private void OnLostFocus() {
+            Close();
+        }
+
         private void OnDisable()
         {
             OnMenuSelected = (menu) => { };

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvMenuTreeView.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvMenuTreeView.cs
@@ -30,7 +30,8 @@ namespace nadena.dev.modular_avatar.core.editor
             _treeView.OnDoubleclickSelect = Close;
         }
 
-        private void OnLostFocus() {
+        private void OnLostFocus() 
+        {
             Close();
         }
 


### PR DESCRIPTION
I felt that this type of selection window should close automatically when it loses focus.
(For example, a selection window for an ObjectField, etc.).
Now I could make it close automatically when it loses focus, but I think I could also get closer by using `ShowAuxWindow`.