### PR TITLE
Add validation for menu icons.

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
@@ -205,7 +205,8 @@ namespace nadena.dev.modular_avatar.core.editor
             return _avatarMenus == null || _avatarMenus.Contains(menu);
         }
 
-        private static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(VRCExpressionsMenu menu) {
+        private static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(VRCExpressionsMenu menu) 
+        {
             if (menu == null) return ValidateExpressionMenuIconResult.Success;
             
             foreach (VRCExpressionsMenu.Control control in menu.controls) 

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
@@ -119,7 +119,8 @@ namespace nadena.dev.modular_avatar.core.editor
             }
 
             _devFoldout = EditorGUILayout.Foldout(_devFoldout, G("menuinstall.devoptions"));
-            if (_devFoldout) {
+            if (_devFoldout) 
+            {
                 SerializedProperty menuToAppendProperty = serializedObject.FindProperty(nameof(ModularAvatarMenuInstaller.menuToAppend));
                 switch (ValidateExpressionMenuIcon((VRCExpressionsMenu)menuToAppendProperty.objectReferenceValue)) 
                 {
@@ -207,13 +208,15 @@ namespace nadena.dev.modular_avatar.core.editor
         private static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(VRCExpressionsMenu menu) {
             if (menu == null) return ValidateExpressionMenuIconResult.Success;
             
-            foreach (VRCExpressionsMenu.Control control in menu.controls) {
+            foreach (VRCExpressionsMenu.Control control in menu.controls) 
+            {
                 // Control
                 ValidateExpressionMenuIconResult result = Util.ValidateExpressionMenuIcon(control.icon);
                 if (result != ValidateExpressionMenuIconResult.Success) return result;
                 
                 // Labels
-                foreach (VRCExpressionsMenu.Control.Label label in control.labels) {
+                foreach (VRCExpressionsMenu.Control.Label label in control.labels) 
+                {
                     ValidateExpressionMenuIconResult labelResult = Util.ValidateExpressionMenuIcon(label.icon);
                     if (labelResult != ValidateExpressionMenuIconResult.Success) return labelResult;
                 }

--- a/Packages/nadena.dev.modular-avatar/Editor/Localization/en.json
+++ b/Packages/nadena.dev.modular-avatar/Editor/Localization/en.json
@@ -9,6 +9,8 @@
   "menuinstall.showcontents": "Show menu contents",
   "menuinstall.showcontents.notselected": "No menu selected",
   "menuinstall.devoptions": "Prefab Developer Options",
+  "menuinstall.menu_icon_too_large" : "The icon set in the menu is too large than 256 pixels.",
+  "menuinstall.menu_icon_uncompressed" : "The icon set in the menu is not set for compression.",
   "menuinstall.srcmenu": "Menu to Install",
   "params.autodetect_header": "   Autodetected Parameters   ",
   "params.internal": "Internal",

--- a/Packages/nadena.dev.modular-avatar/Editor/Localization/ja.json
+++ b/Packages/nadena.dev.modular-avatar/Editor/Localization/ja.json
@@ -9,6 +9,8 @@
   "menuinstall.showcontents": "メニュー内容を表示",
   "menuinstall.showcontents.notselected": "メニューが選択されていません",
   "menuinstall.devoptions": "プレハブ開発者向け設定",
+  "menuinstall.menu_icon_too_large" : "メニューに設定されているアイコンが256ピクセルより大きすぎます。",
+  "menuinstall.menu_icon_uncompressed" : "メニューに設定されているアイコンが圧縮設定されていません。",
   "menuinstall.srcmenu": "インストールされるメニュー",
   "params.autodetect_header": "   自動検出されたパラメーター   ",
   "params.internal": "内部値",

--- a/Packages/nadena.dev.modular-avatar/Editor/Util.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Util.cs
@@ -27,6 +27,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using UnityEditor;
 using UnityEditor.Animations;
+using UnityEngine;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Object = UnityEngine.Object;
 
@@ -138,5 +139,33 @@ namespace nadena.dev.modular_avatar.core.editor
 
             return avatarValidation;
         }
+
+        private const int MAX_EXPRESSION_TEXTURE_SIZE = 256;
+
+        public enum ValidateExpressionMenuIconResult 
+        {
+            Success,
+            TooLarge,
+            Uncompressed
+        }
+
+        public static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(Texture2D icon) 
+        {
+            string path = AssetDatabase.GetAssetPath(icon);
+            TextureImporter importer = AssetImporter.GetAtPath(path) as TextureImporter;
+            if (importer == null) return ValidateExpressionMenuIconResult.Success;
+            TextureImporterPlatformSettings settings = importer.GetDefaultPlatformTextureSettings();
+            
+            // Max texture size;
+            if ((icon.width > MAX_EXPRESSION_TEXTURE_SIZE || icon.height > MAX_EXPRESSION_TEXTURE_SIZE) &&
+                settings.maxTextureSize > MAX_EXPRESSION_TEXTURE_SIZE) return ValidateExpressionMenuIconResult.TooLarge;
+            
+            // Compression
+            if (settings.textureCompression == TextureImporterCompression.Uncompressed) return ValidateExpressionMenuIconResult.Uncompressed;
+            return ValidateExpressionMenuIconResult.Success;
+        }
+        
+        
+        
     }
 }


### PR DESCRIPTION
The VRCSDK has a size limit and a compression setting limit for MenuIcon.
If there are icons in the MenuInstaller menu that exceed these limits, they are uploaded as they are.
The upload itself is normal, and there is no problem with VRC operation, but at least an error occurs in the performance window, so it would be better to at least send an error to MenuInstaller.

Depending on the situation, it may be necessary to remove the icon or make an error when building, but since the menu settings themselves are the responsibility of the asset creator, it may be better to simply warn the author so as not to cause confusion among asset users.