### PR TITLE
Support for AnimatorOverrideController

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/RenameParametersHook.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/RenameParametersHook.cs
@@ -126,6 +126,12 @@ namespace nadena.dev.modular_avatar.core.editor
                     {
                         if (willPurgeAnimators) break; // animator will be deleted in subsequent processing
 
+                        // RuntimeAnimatorController may be AnimatorOverrideController, convert in case of AnimatorOverrideController
+                        if (anim.runtimeAnimatorController is AnimatorOverrideController overrideController) 
+                        {
+                            anim.runtimeAnimatorController = Util.ConvertAnimatorController(overrideController);
+                        }
+
                         var controller = anim.runtimeAnimatorController as AnimatorController;
                         if (controller != null)
                         {
@@ -138,6 +144,12 @@ namespace nadena.dev.modular_avatar.core.editor
 
                     case ModularAvatarMergeAnimator merger:
                     {
+                        
+                        // RuntimeAnimatorController may be AnimatorOverrideController, convert in case of AnimatorOverrideController
+                        if (merger.animator is AnimatorOverrideController overrideController) 
+                        {
+                            merger.animator = Util.ConvertAnimatorController(overrideController);
+                        }
                         var controller = merger.animator as AnimatorController;
                         if (controller != null)
                         {

--- a/Packages/nadena.dev.modular-avatar/Editor/Util.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Util.cs
@@ -118,6 +118,13 @@ namespace nadena.dev.modular_avatar.core.editor
             return merger.Finish();
         }
 
+        public static AnimatorController ConvertAnimatorController(AnimatorOverrideController overrideController) 
+        {
+            var merger = new AnimatorCombiner();
+            merger.AddOverrideController("", overrideController, null);
+            return merger.Finish();
+        }
+
         public static bool IsTemporaryAsset(Object obj)
         {
             var path = AssetDatabase.GetAssetPath(obj);


### PR DESCRIPTION
#138 

Added process to convert `AnimatorOverrideController` to `AnimatorController` during `Animator` and `ModularAvatarMergeAnimator` processes of `RenameParametersHook`.