### PR TITLE
Fixed Unity crashes when setting a menu with circular references to MenuInstaller.

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/MenuInstallerEditor.cs
@@ -205,9 +205,12 @@ namespace nadena.dev.modular_avatar.core.editor
             return _avatarMenus == null || _avatarMenus.Contains(menu);
         }
 
-        private static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(VRCExpressionsMenu menu) 
+        private static ValidateExpressionMenuIconResult ValidateExpressionMenuIcon(VRCExpressionsMenu menu, HashSet<VRCExpressionsMenu> visitedMenus = null) 
         {
             if (menu == null) return ValidateExpressionMenuIconResult.Success;
+            if (visitedMenus == null) visitedMenus = new HashSet<VRCExpressionsMenu>();
+            if (visitedMenus.Contains(menu)) return ValidateExpressionMenuIconResult.Success;
+            visitedMenus.Add(menu);
             
             foreach (VRCExpressionsMenu.Control control in menu.controls) 
             {
@@ -224,7 +227,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 
                 // SubMenu
                 if (control.type != VRCExpressionsMenu.Control.ControlType.SubMenu) continue;
-                ValidateExpressionMenuIconResult subMenuResult = ValidateExpressionMenuIcon(control.subMenu);
+                ValidateExpressionMenuIconResult subMenuResult = ValidateExpressionMenuIcon(control.subMenu, visitedMenus);
                 if (subMenuResult != ValidateExpressionMenuIconResult.Success) return subMenuResult;
             }
             


### PR DESCRIPTION
すみません。
私が作成したコードにバグが存在しました。

### トリガー
- MenuInstallerに循環参照を持つメニューを設定する
- MenuInstallerに循環参照を持つメニューが設定されてる状態で`開発者向け設定`Foldoutを開く
### 原因
メニューアイコンのバリテーションの際に無限ループに突入してしまうため。
### 対策
一度バリエーションを行ったメニューの場合`Success`を返すように変更
- すでに1度バリテーションが行われてる際は、`Success`が返ってないと、再度同じメニューに処理が走ることは無いため
 - 親の層でバリテーションが行われている途中の場合は、`Success`を返していても親の層の処理を再開した際に正しい結果が返るため