### PR TITLE
Workaround Merge Armature breaking parent PBs

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
@@ -327,6 +327,9 @@ namespace nadena.dev.modular_avatar.core.editor
                     transformPath = RuntimeUtil.AvatarRootPath(newParent),
                     path = srcPath
                 });
+                // The new merged leaf (if it's retained below) can break parent bone physbones. Add a PB Blocker
+                // to prevent this becoming an issue.
+                mergedSrcBone.GetOrAddComponent<ModularAvatarPBBlocker>();
             }
 
             BoneRemappings[src.transform] = mergedSrcBone.transform;


### PR DESCRIPTION
The Merge Armature logic is in need of an overall rewrite, but this works around
issues where added (duplicate) bones break PBs in parents, by adding these to parent PB ignore lists.
