### PR TITLE
Meshが空のSkinnedMeshRendererがあるとActionGeneratorがエラーを起こすのを修正

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Menu/ActionProcessing/ActionGenerator.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Menu/ActionProcessing/ActionGenerator.cs
@@ -110,6 +110,7 @@ namespace nadena.dev.modular_avatar.core.editor
             AnimationClip clip = new AnimationClip();
             foreach (var renderer in avatar.GetComponentsInChildren<SkinnedMeshRenderer>())
             {
+                if (!renderer.sharedMesh)  continue;
                 int nShapes = renderer.sharedMesh.blendShapeCount;
                 for (int i = 0; i < nShapes; i++)
                 {


### PR DESCRIPTION
Fix #279 

Meshが空のSkinnedMeshRendererがアバター内にある際、ActionGeneratorがNullReferenceExceptionを吐くことの修正です。