### PR TITLE
空のSubMenuがあるとMenuInstallerの表示でエラーが発生するのを修正

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/Menu/MenuInstallerEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/Menu/MenuInstallerEditor.cs
@@ -469,7 +469,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 _avatarMenus.Add(menu);
                 foreach (var subMenu in menu.controls)
                 {
-                    if (subMenu.type == VRCExpressionsMenu.Control.ControlType.SubMenu)
+                    if (subMenu.type == VRCExpressionsMenu.Control.ControlType.SubMenu && subMenu.subMenu != null)
                     {
                         queue.Enqueue(subMenu.subMenu);
                     }


### PR DESCRIPTION
Fix #281 

空のSubMenuを持つアバターにおいて、MenuInstallerのInspector表示をするとNullReferenceExceptionを吐くことの修正です。