### PR TITLE
Add object remover component

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/AvatarProcessor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/AvatarProcessor.cs
@@ -191,6 +191,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
                         var context = new BuildContext(vrcAvatarDescriptor);
 
+                        ObjectRemoverProcessor.OnPreprocessAvatar(avatarGameObject);
                         new RenameParametersHook().OnPreprocessAvatar(avatarGameObject, context);
                         new MergeAnimatorProcessor().OnPreprocessAvatar(avatarGameObject, context);
                         context.AnimationDatabase.Bootstrap(vrcAvatarDescriptor);
@@ -201,7 +202,6 @@ namespace nadena.dev.modular_avatar.core.editor
                         new VisibleHeadAccessoryProcessor(vrcAvatarDescriptor).Process(context);
                         new RemapAnimationPass(vrcAvatarDescriptor).Process(context.AnimationDatabase);
                         new BlendshapeSyncAnimationProcessor().OnPreprocessAvatar(avatarGameObject, context);
-                        ObjectRemoverProcessor.OnPreprocessAvatar(avatarGameObject);
                         PhysboneBlockerPass.Process(avatarGameObject);
 
                         AfterProcessing?.Invoke(avatarGameObject, context);

--- a/Packages/nadena.dev.modular-avatar/Editor/AvatarProcessor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/AvatarProcessor.cs
@@ -201,6 +201,7 @@ namespace nadena.dev.modular_avatar.core.editor
                         new VisibleHeadAccessoryProcessor(vrcAvatarDescriptor).Process(context);
                         new RemapAnimationPass(vrcAvatarDescriptor).Process(context.AnimationDatabase);
                         new BlendshapeSyncAnimationProcessor().OnPreprocessAvatar(avatarGameObject, context);
+                        ObjectRemoverProcessor.OnPreprocessAvatar(avatarGameObject);
                         PhysboneBlockerPass.Process(avatarGameObject);
 
                         AfterProcessing?.Invoke(avatarGameObject, context);

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEditor;
+using UnityEditorInternal;
 using UnityEngine;
 using static nadena.dev.modular_avatar.core.editor.Localization;
 
@@ -8,22 +9,42 @@ namespace nadena.dev.modular_avatar.core.editor
     internal class ObjectRemoverEditor : MAEditorBase
     {
         private SerializedProperty prop_hideInHierarchy;
+        private SerializedProperty prop_keepDisabled;
+        private SerializedProperty prop_removePrefabComponents;
+        private SerializedProperty prop_objectsToRemove;
+        ReorderableList myListReorderableList;
 
         private void OnEnable()
         {
             prop_hideInHierarchy = serializedObject.FindProperty(nameof(ModularAvatarObjectRemover.hideInHierarchy));
+            prop_keepDisabled = serializedObject.FindProperty(nameof(ModularAvatarObjectRemover.keepDisabled));
+            prop_removePrefabComponents = serializedObject.FindProperty(nameof(ModularAvatarObjectRemover.removePrefabComponents));
+            prop_objectsToRemove = serializedObject.FindProperty(nameof(ModularAvatarObjectRemover.objectsToRemove));
         }
 
         protected override void OnInnerInspectorGUI()
         {
             serializedObject.Update();
-            if (GUILayout.Button(G("object_remover.hide")))
-            {
-                prop_hideInHierarchy.boolValue = true;
-                ((ModularAvatarObjectRemover)target).Hide();
-            }
+            var remover = (ModularAvatarObjectRemover)target;
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(prop_hideInHierarchy, G("object_remover.hide"));
+            bool hideChanged = EditorGUI.EndChangeCheck();
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(prop_removePrefabComponents, G("object_remover.remove_components"));
+            bool removeChanged = EditorGUI.EndChangeCheck();
+
+            EditorGUILayout.PropertyField(prop_keepDisabled, G("object_remover.keep_disabled"));
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(prop_objectsToRemove, G("object_remover.to_remove"));
+            bool listChanged = EditorGUI.EndChangeCheck();
 
             serializedObject.ApplyModifiedProperties();
+            if (hideChanged || removeChanged || listChanged) remover.OnListChange();
+            if (hideChanged && !prop_hideInHierarchy.boolValue) remover.Unhide();
+            if (removeChanged && !prop_removePrefabComponents.boolValue) remover.RestorePrefabComponents();
         }
     }
 }

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs
@@ -1,0 +1,29 @@
+﻿using UnityEditor;
+using UnityEngine;
+using static nadena.dev.modular_avatar.core.editor.Localization;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [CustomEditor(typeof(ModularAvatarObjectRemover))]
+    internal class ObjectRemoverEditor : MAEditorBase
+    {
+        private SerializedProperty prop_hideInHierarchy;
+
+        private void OnEnable()
+        {
+            prop_hideInHierarchy = serializedObject.FindProperty(nameof(ModularAvatarObjectRemover.hideInHierarchy));
+        }
+
+        protected override void OnInnerInspectorGUI()
+        {
+            serializedObject.Update();
+            if (GUILayout.Button(G("object_remover.hide")))
+            {
+                prop_hideInHierarchy.boolValue = true;
+                ((ModularAvatarObjectRemover)target).Hide();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs.meta
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/ObjectRemoverEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ea6fd9437d1c4e37bfccb600dac11374
+timeCreated: 1682377686

--- a/Packages/nadena.dev.modular-avatar/Editor/Localization/en.json
+++ b/Packages/nadena.dev.modular-avatar/Editor/Localization/en.json
@@ -29,6 +29,7 @@
   "params.syncmode.Int": "Int",
   "params.syncmode.Float": "Float",
   "params.syncmode.Bool": "Bool",
+  "object_remover.hide": "Hide in hierarchy",
   "merge_armature.merge_target": "Merge Target",
   "merge_armature.merge_target.tooltip": "The armature (or subtree) to merge this object into",
   "merge_armature.prefix": "Prefix",

--- a/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
@@ -1,0 +1,30 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    public static class ObjectRemoverProcessor
+    {
+        internal static void OnPreprocessAvatar(GameObject avatarGameObject)
+        {
+            var toRemove = avatarGameObject.transform.GetComponentsInChildren<ModularAvatarObjectRemover>(true);
+
+            foreach (var remove in toRemove)
+            {
+                Object.DestroyImmediate(remove.gameObject);
+            }
+        }
+
+
+        [MenuItem("GameObject/ModularAvatar/Restore Removed", false, 49)]
+        static void RestoreRemoved(MenuCommand menuCommand)
+        {
+            if (!(menuCommand.context is GameObject obj)) return;
+            foreach (Transform child in obj.transform)
+            {
+                var toRemove = child.GetComponent<ModularAvatarObjectRemover>();
+                if (toRemove != null) toRemove.Restore();
+            }
+        }
+    }
+}

--- a/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
@@ -1,5 +1,4 @@
-﻿using UnityEditor;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -7,23 +6,10 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         internal static void OnPreprocessAvatar(GameObject avatarGameObject)
         {
-            var toRemove = avatarGameObject.transform.GetComponentsInChildren<ModularAvatarObjectRemover>(true);
-
-            foreach (var remove in toRemove)
+            var removers = avatarGameObject.transform.GetComponentsInChildren<ModularAvatarObjectRemover>(true);
+            foreach (var remover in removers)
             {
-                Object.DestroyImmediate(remove.gameObject);
-            }
-        }
-
-
-        [MenuItem("GameObject/ModularAvatar/Restore Removed", false, 49)]
-        static void RestoreRemoved(MenuCommand menuCommand)
-        {
-            if (!(menuCommand.context is GameObject obj)) return;
-            foreach (Transform child in obj.transform)
-            {
-                var toRemove = child.GetComponent<ModularAvatarObjectRemover>();
-                if (toRemove != null) toRemove.Restore();
+                foreach (var toRemove in remover.objectsToRemove) Object.DestroyImmediate(toRemove);
             }
         }
     }

--- a/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -7,10 +8,13 @@ namespace nadena.dev.modular_avatar.core.editor
         internal static void OnPreprocessAvatar(GameObject avatarGameObject)
         {
             var removers = avatarGameObject.transform.GetComponentsInChildren<ModularAvatarObjectRemover>(true);
+            var objectsToRemove = new List<GameObject>();
             foreach (var remover in removers)
             {
-                foreach (var toRemove in remover.objectsToRemove) Object.DestroyImmediate(toRemove);
+                objectsToRemove.AddRange(remover.objectsToRemove);
             }
+
+            foreach (var toRemove in objectsToRemove) Object.DestroyImmediate(toRemove);
         }
     }
 }

--- a/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs.meta
+++ b/Packages/nadena.dev.modular-avatar/Editor/ObjectRemoverProcessor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 50586209a53d4a96876484f177fcfc69
+timeCreated: 1682373125

--- a/Packages/nadena.dev.modular-avatar/Editor/RemapAnimationPass.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/RemapAnimationPass.cs
@@ -54,6 +54,7 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 var newBinding = binding;
                 newBinding.path = MapPath(binding);
+                if (newBinding.path == null) continue; // removed
                 newClip.SetCurve(newBinding.path, newBinding.type, newBinding.propertyName,
                     AnimationUtility.GetEditorCurve(clip, binding));
             }

--- a/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
@@ -1,0 +1,52 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core
+{
+    [ExecuteInEditMode]
+    [DisallowMultipleComponent]
+    [AddComponentMenu("Modular Avatar/MA Object Remover")]
+    public class ModularAvatarObjectRemover : AvatarTagComponent
+    {
+        public bool hideInHierarchy;
+
+        public ModularAvatarObjectRemover()
+        {
+            EditorApplication.delayCall += Refresh;
+        }
+
+        private void OnEnable()
+        {
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            if (Application.isPlaying) return;
+            gameObject.SetActive(false);
+            if (hideInHierarchy) Hide();
+            // components can be always restored from prefabs, so removing them now does not break anything and will
+            // provide better compatibility with other tools
+            foreach (var componentsInChild in gameObject.GetComponentsInChildren<MeshRenderer>())
+            {
+                if (PrefabUtility.IsPartOfAnyPrefab(componentsInChild)) DestroyImmediate(componentsInChild);
+            }
+            foreach (var componentsInChild in gameObject.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                if (PrefabUtility.IsPartOfAnyPrefab(componentsInChild)) DestroyImmediate(componentsInChild);
+            }
+        }
+
+        public void Hide()
+        {
+            hideInHierarchy = true;
+            gameObject.hideFlags |= HideFlags.HideInHierarchy;
+        }
+
+        public void Restore()
+        {
+            hideInHierarchy = false;
+            gameObject.hideFlags &= ~HideFlags.HideInHierarchy;
+        }
+    }
+}

--- a/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
@@ -1,52 +1,132 @@
-﻿using UnityEditor;
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core
 {
     [ExecuteInEditMode]
-    [DisallowMultipleComponent]
     [AddComponentMenu("Modular Avatar/MA Object Remover")]
     public class ModularAvatarObjectRemover : AvatarTagComponent
     {
-        public bool hideInHierarchy;
-
-        public ModularAvatarObjectRemover()
-        {
-            EditorApplication.delayCall += Refresh;
-        }
+        public bool hideInHierarchy = true;
+        public bool keepDisabled = true;
+        public bool removePrefabComponents;
+        public List<GameObject> objectsToRemove = new List<GameObject>();
+        private List<GameObject> _lastObjectsToRemove;
 
         private void OnEnable()
         {
-            Refresh();
+            objectsToRemove?.RemoveAll(x => !x);
+            OnListChange();
         }
 
-        private void Refresh()
+        private void Update()
         {
             if (Application.isPlaying) return;
-            gameObject.SetActive(false);
+            if (!keepDisabled) return;
+            if (objectsToRemove == null) return;
+            foreach (var toRemove in objectsToRemove) toRemove.SetActive(false);
+        }
+        
+        private new void OnDestroy()
+        {
+            if (Application.isPlaying) return;
+            hideInHierarchy = false;
+            removePrefabComponents = false;
+            Unhide();
+            RestorePrefabComponents();
+            objectsToRemove.Clear();
+            _lastObjectsToRemove = null;
+        }
+
+        public void OnListChange()
+        {
+            objectsToRemove.RemoveAll(x => !x);
+            if (Application.isPlaying) return;
+            if (_lastObjectsToRemove != null)
+            {
+                foreach (var newValue in objectsToRemove) _lastObjectsToRemove.Remove(newValue);
+                foreach (var removedFromList in _lastObjectsToRemove)
+                {
+                    if (!removedFromList) continue;
+                    removedFromList.hideFlags &= ~HideFlags.HideInHierarchy;
+                    foreach (var removedComponent in CollectComponentsToRestore(new List<RemovedComponent>(), removedFromList.transform))
+                    {
+                        removedComponent.Revert();
+                    }
+                }
+            }
+
+            _lastObjectsToRemove = new List<GameObject>(objectsToRemove);
             if (hideInHierarchy) Hide();
-            // components can be always restored from prefabs, so removing them now does not break anything and will
-            // provide better compatibility with other tools
-            foreach (var componentsInChild in gameObject.GetComponentsInChildren<MeshRenderer>())
+            if (removePrefabComponents) RemovePrefabComponents();
+        }
+
+        private void CollectComponentsToRemove(List<Component> list, Transform current)
+        {
+            list.AddRange(current.GetComponents(typeof(Component)).Where(PrefabUtility.IsPartOfAnyPrefab));
+            foreach (Transform child in current)
             {
-                if (PrefabUtility.IsPartOfAnyPrefab(componentsInChild)) DestroyImmediate(componentsInChild);
+                CollectComponentsToRemove(list, child);
             }
-            foreach (var componentsInChild in gameObject.GetComponentsInChildren<SkinnedMeshRenderer>())
+        }
+
+        private List<RemovedComponent> CollectComponentsToRestore(List<RemovedComponent> list, Transform current)
+        {
+            if (!PrefabUtility.IsPartOfAnyPrefab(current.gameObject)) return list;
+            list.AddRange(PrefabUtility.GetRemovedComponents(current.gameObject));
+            foreach (Transform child in current)
             {
-                if (PrefabUtility.IsPartOfAnyPrefab(componentsInChild)) DestroyImmediate(componentsInChild);
+                CollectComponentsToRestore(list, child);
             }
+
+            return list;
+        }
+
+        public void RemovePrefabComponents()
+        {
+            var toDelete = new List<Component>();
+
+            foreach (var toRemove in objectsToRemove)
+            {
+                if (removePrefabComponents) CollectComponentsToRemove(toDelete, toRemove.transform);
+            }
+
+            // NOTE: this is non-destructive, all components from prefabs can be restored with no data loss
+            foreach (var component in toDelete)
+            {
+                if (component is Transform) continue;
+                DestroyImmediate(component);
+            }
+        }
+
+        public void RestorePrefabComponents()
+        {
+            var toRestore = new List<RemovedComponent>();
+            foreach (var obj in objectsToRemove)
+            {
+                CollectComponentsToRestore(toRestore, obj.transform);
+            }
+
+            foreach (var removedComponent in toRestore) removedComponent.Revert();
         }
 
         public void Hide()
         {
-            hideInHierarchy = true;
-            gameObject.hideFlags |= HideFlags.HideInHierarchy;
+            foreach (var obj in objectsToRemove)
+            {
+                obj.hideFlags |= HideFlags.HideInHierarchy;
+            }
         }
 
-        public void Restore()
+        public void Unhide()
         {
-            hideInHierarchy = false;
-            gameObject.hideFlags &= ~HideFlags.HideInHierarchy;
+            foreach (var obj in objectsToRemove)
+            {
+                obj.hideFlags &= ~HideFlags.HideInHierarchy;
+            }
         }
     }
 }

--- a/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
@@ -22,14 +22,6 @@ namespace nadena.dev.modular_avatar.core
             OnListChange();
         }
 
-        private void Update()
-        {
-            if (Application.isPlaying) return;
-            if (!keepDisabled) return;
-            if (objectsToRemove == null) return;
-            foreach (var toRemove in objectsToRemove) toRemove.SetActive(false);
-        }
-        
         private new void OnDestroy()
         {
             if (Application.isPlaying) return;
@@ -62,6 +54,10 @@ namespace nadena.dev.modular_avatar.core
             _lastObjectsToRemove = new List<GameObject>(objectsToRemove);
             if (hideInHierarchy) Hide();
             if (removePrefabComponents) RemovePrefabComponents();
+            if (keepDisabled)
+            {
+                foreach (var obj in objectsToRemove) obj.SetActive(false);
+            }
         }
 
         private void CollectComponentsToRemove(List<Component> list, Transform current)
@@ -117,7 +113,7 @@ namespace nadena.dev.modular_avatar.core
         {
             foreach (var obj in objectsToRemove)
             {
-                obj.hideFlags |= HideFlags.HideInHierarchy;
+                if (IsSafeToBeHidden(obj)) obj.hideFlags |= HideFlags.HideInHierarchy;
             }
         }
 
@@ -127,6 +123,11 @@ namespace nadena.dev.modular_avatar.core
             {
                 obj.hideFlags &= ~HideFlags.HideInHierarchy;
             }
+        }
+
+        private bool IsSafeToBeHidden(GameObject obj)
+        {
+            return obj.GetComponentInChildren<ModularAvatarObjectRemover>(true) == null;
         }
     }
 }

--- a/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs
@@ -18,7 +18,6 @@ namespace nadena.dev.modular_avatar.core
 
         private void OnEnable()
         {
-            objectsToRemove?.RemoveAll(x => !x);
             OnListChange();
         }
 

--- a/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs.meta
+++ b/Packages/nadena.dev.modular-avatar/Runtime/ModularAvatarObjectRemover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ca2ef287faa455398e599ecd7bd1188
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: a8edd5bd1a0a64a40aa99cc09fb5f198, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A simple component that you can put on any object to just remove it during the build, additionaly a button can be used to hide it from hierarchy view too (it's not removed, just hidden, right click on parent object can be used to restore it) making your avatar setup much more clean if you often only use parts of some avatars/clothing.


![image](https://user-images.githubusercontent.com/6942692/234141051-35a1c635-c774-42a2-9fd3-5c69188a2876.png)
![image](https://user-images.githubusercontent.com/6942692/234141074-816967ff-6d1a-43ab-89d1-89c21a7fd7d7.png)

Comparsion on my sample avatar before and after adding this component: 
![image](https://user-images.githubusercontent.com/6942692/234141366-f0232324-cebe-410f-bf31-b8abded3eb39.png)
![image](https://user-images.githubusercontent.com/6942692/234143103-ab810b2b-8619-4e3f-867f-0a33106abcdb.png)


