### PR TITLE
CRITICAL: Fixed missing namespaces that are required by SDK 3.2.x

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
@@ -33,6 +33,7 @@ using VRC.Dynamics;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 using Object = UnityEngine.Object;
+using VRC.Core;
 
 namespace nadena.dev.modular_avatar.core.editor
 {

--- a/Packages/nadena.dev.modular-avatar/Runtime/Activator.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/Activator.cs
@@ -6,6 +6,7 @@ using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using VRC.SDK3.Avatars.Components;
+using VRC.Core;
 
 namespace nadena.dev.modular_avatar.core
 {


### PR DESCRIPTION
Modular Avatar will cease to work with the new SDK 3.2.0 due to changes to the Extension Methods being moved to the VRC.Core namespace. So a critical change has been made in order to make sure it works again.

I have went ahead and added them as part of this Pull Request. **As this is backwards-compatible, it is highly advised that this gets merged ASAP so that Modular Avatar can function properly on SDK 3.2.0 once it's released to the Public.**

