### PR TITLE
fix: SDK 3.2.0 compatibility (add using reference)

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/MergeArmatureHook.cs
@@ -29,6 +29,7 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
+using VRC.Core;
 using VRC.Dynamics;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Dynamics.PhysBone.Components;

--- a/Packages/nadena.dev.modular-avatar/Runtime/Activator.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/Activator.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using VRC.Core;
 using VRC.SDK3.Avatars.Components;
 
 namespace nadena.dev.modular_avatar.core


### PR DESCRIPTION
VRCSDK v3.2.0 更新の際の変更に対応

v1.5.0で対応予定のようですが、とりあえずの対応用です。