### PR TITLE
Gc pass will now scan for unused bones and cleanup physbones and colliders

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/OptimizationPasses/GCGameObjectsPass.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/OptimizationPasses/GCGameObjectsPass.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using VRC.Dynamics;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -13,7 +15,13 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         private readonly BuildContext _context;
         private readonly GameObject _root;
-        private readonly HashSet<GameObject> referencedGameObjects = new HashSet<GameObject>();
+        private readonly HashSet<GameObject> _referencedGameObjects = new HashSet<GameObject>();
+        private readonly HashSet<GameObject> _allBones = new HashSet<GameObject>();
+        private readonly HashSet<GameObject> _usedBones = new HashSet<GameObject>();
+        private readonly HashSet<VRCPhysBone> _physBones = new HashSet<VRCPhysBone>();
+        private readonly HashSet<VRCPhysBoneColliderBase> _physBoneColliders = new HashSet<VRCPhysBoneColliderBase>();
+        private int _removedObjects;
+        private int _removedComponents;
 
         internal GCGameObjectsPass(BuildContext context, GameObject root)
         {
@@ -23,11 +31,132 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal void OnPreprocessAvatar()
         {
+            CollectReferences();
+            Cleanup();
             MarkAll();
             Sweep();
+            Debug.Log($"Cleanup complete, removed {_removedObjects} objects and {_removedComponents} components.");
         }
 
+        private void CollectReferences()
+        {
+            LoopAllComponents((obj, component) =>
+            {
+                switch (component)
+                {
+                    case SkinnedMeshRenderer mesh:
+                        CollectBonesFromSkinnedMeshRenderer(mesh);
+                        break;
+
+                    case VRCPhysBone pb:
+                        _physBones.Add(pb);
+                        break;
+                    case VRCPhysBoneCollider collider:
+                        _physBoneColliders.Add(collider);
+                        break;
+                }
+            });
+        }
+
+        private void CollectBonesFromSkinnedMeshRenderer(SkinnedMeshRenderer renderer)
+        {
+            HashSet<int> usedBonesIndices = new HashSet<int>();
+            foreach (var boneWeight in renderer.sharedMesh.boneWeights)
+            {
+                // technically should add only if weight is > 0, but not worth the cost and does not have negative effects
+                usedBonesIndices.Add(boneWeight.boneIndex0);
+                usedBonesIndices.Add(boneWeight.boneIndex1);
+                usedBonesIndices.Add(boneWeight.boneIndex2);
+                usedBonesIndices.Add(boneWeight.boneIndex3);
+            }
+
+            Transform[] bones = renderer.bones;
+            foreach (var usedBoneIndex in usedBonesIndices)
+            {
+                Transform usedBone = bones[usedBoneIndex];
+                if (usedBone != null) _usedBones.Add(usedBone.gameObject);
+            }
+
+            foreach (var bone in bones)
+            {
+                if (bone != null) _allBones.Add(bone.gameObject);
+            }
+        }
+
+        private void Cleanup()
+        {
+            // remove phys bones that only affect bones that are not used
+            var bonesToRemove = new HashSet<VRCPhysBone>();
+            foreach (var vrcPhysBone in _physBones)
+            {
+                vrcPhysBone.InitTransforms();
+                if (vrcPhysBone.bones.Any(x => _usedBones.Contains(x.transform.gameObject))) continue;
+                // in case someone uses the component on chain of something that is not actually a bone
+                if (vrcPhysBone.bones.Any(x => !_allBones.Contains(x.transform.gameObject))) continue;
+                bonesToRemove.Add(vrcPhysBone);
+            }
+
+            foreach (var vrcPhysBone in bonesToRemove)
+            {
+                _physBones.Remove(vrcPhysBone);
+                PurgeComponent(vrcPhysBone);
+            }
+
+            // remove all colliders that no longer collide with anything
+            var collidersToRemove = new HashSet<VRCPhysBoneColliderBase>(_physBoneColliders);
+            foreach (var vrcPhysBone in _physBones)
+            {
+                foreach (var vrcPhysBoneColliderBase in vrcPhysBone.colliders)
+                {
+                    collidersToRemove.Remove(vrcPhysBoneColliderBase);
+                }
+            }
+
+            foreach (var collider in collidersToRemove)
+            {
+                _physBoneColliders.Remove(collider);
+                PurgeComponent(collider);
+            }
+        }
+
+
         private void MarkAll()
+        {
+            foreach (var gameObject in _usedBones)
+            {
+                MarkObject(gameObject);
+            }
+
+            LoopAllComponents((obj, component) =>
+                {
+                    switch (component)
+                    {
+                        case Transform _: break;
+
+                        case SkinnedMeshRenderer mesh:
+                            MarkObject(obj);
+                            MarkSkinnedMeshRenderer(mesh);
+                            break;
+
+                        case VRCPhysBone pb:
+                            MarkObject(obj);
+                            MarkPhysBone(pb);
+                            break;
+
+                        case AvatarTagComponent _:
+                            // Tag components will not be retained at runtime, so pretend they're not there.
+                            break;
+
+                        default:
+                            MarkObject(obj);
+                            MarkAllReferencedObjects(component);
+                            break;
+                    }
+                }
+            );
+        }
+
+        private void LoopAllComponents(Action<GameObject, Component> action)
         {
             foreach (var obj in GameObjects(_root,
                          node =>
@@ -50,26 +179,17 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 foreach (var component in obj.GetComponents<Component>())
                 {
-                    switch (component)
-                    {
-                        case Transform t: break;
-
-                        case VRCPhysBone pb:
-                            MarkObject(obj);
-                            MarkPhysBone(pb);
-                            break;
-
-                        case AvatarTagComponent _:
-                            // Tag components will not be retained at runtime, so pretend they're not there.
-                            break;
-
-                        default:
-                            MarkObject(obj);
-                            MarkAllReferencedObjects(component);
-                            break;
-                    }
+                    if (component == null) continue;
+                    action(obj, component);
                 }
             }
+        }
+
+        private void MarkSkinnedMeshRenderer(SkinnedMeshRenderer renderer)
+        {
+            MarkObject(renderer.lightProbeProxyVolumeOverride);
+            MarkObject(renderer.rootBone);
+            MarkObject(renderer.probeAnchor);
         }
 
         private void MarkPhysBone(VRCPhysBone pb)
@@ -120,9 +240,14 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
+        private void MarkObject(Transform go)
+        {
+            if (go != null) MarkObject(go.gameObject);
+        }
+
         private void MarkObject(GameObject go)
         {
-            while (go != null && referencedGameObjects.Add(go) && go != _root)
+            while (go != null && _referencedGameObjects.Add(go) && go != _root)
             {
                 go = go.transform.parent?.gameObject;
             }
@@ -132,12 +257,26 @@ namespace nadena.dev.modular_avatar.core.editor
         {
             foreach (var go in GameObjects())
             {
-                if (!referencedGameObjects.Contains(go))
+                if (!_referencedGameObjects.Contains(go))
                 {
-                    Debug.Log("Purging object: " + RuntimeUtil.AvatarRootPath(go));
-                    UnityEngine.Object.DestroyImmediate(go);
+                    PurgeObject(go);
                 }
             }
+        }
+
+        private void PurgeObject(GameObject go)
+        {
+            Debug.Log("Purging object: " + RuntimeUtil.AvatarRootPath(go));
+            UnityEngine.Object.DestroyImmediate(go);
+            _removedObjects += 1;
+        }
+
+        private void PurgeComponent(Component component)
+        {
+            Debug.Log("Purging component: " + RuntimeUtil.AvatarRootPath(component.gameObject) + "::" +
+                      component.GetType().Name);
+            UnityEngine.Object.DestroyImmediate(component);
+            _removedComponents += 1;
         }
 
         private IEnumerable<GameObject> GameObjects(GameObject node = null,

--- a/Packages/nadena.dev.modular-avatar/Editor/OptimizationPasses/GCGameObjectsPass.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/OptimizationPasses/GCGameObjectsPass.cs
@@ -32,7 +32,7 @@ namespace nadena.dev.modular_avatar.core.editor
         internal void OnPreprocessAvatar()
         {
             CollectReferences();
-            Cleanup();
+            CleanupPhysBones();
             MarkAll();
             Sweep();
             Debug.Log($"Cleanup complete, removed {_removedObjects} objects and {_removedComponents} components.");
@@ -61,13 +61,9 @@ namespace nadena.dev.modular_avatar.core.editor
         private void CollectBonesFromSkinnedMeshRenderer(SkinnedMeshRenderer renderer)
         {
             HashSet<int> usedBonesIndices = new HashSet<int>();
-            foreach (var boneWeight in renderer.sharedMesh.boneWeights)
+            foreach (var boneWeight in renderer.sharedMesh.GetAllBoneWeights())
             {
-                // technically should add only if weight is > 0, but not worth the cost and does not have negative effects
-                usedBonesIndices.Add(boneWeight.boneIndex0);
-                usedBonesIndices.Add(boneWeight.boneIndex1);
-                usedBonesIndices.Add(boneWeight.boneIndex2);
-                usedBonesIndices.Add(boneWeight.boneIndex3);
+                usedBonesIndices.Add(boneWeight.boneIndex);
             }
 
             Transform[] bones = renderer.bones;
@@ -83,7 +79,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        private void Cleanup()
+        private void CleanupPhysBones()
         {
             // remove phys bones that only affect bones that are not used
             var bonesToRemove = new HashSet<VRCPhysBone>();


### PR DESCRIPTION
Currently GC only removes just very simple unreferenced objects, its usually very few objects so it does not help with optimisation or cleanup much. I wrote additional step of GC that collect all bones from all meshes and determines if they are still used or not so they can be correctly removed. Often when merging some avatars you can be left with huge amount of bones from their skirts/hairs if you decided to not use these parts at all. As long as you remove the mesh renderer from the component new GC script will detect this and remove the bones and related dynamic bones and colliders that no longer collide with anything.