### PR TITLE
Change timing of BuildHeightCache

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvatarParametersEditor.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/AvatarParametersEditor.cs
@@ -460,12 +460,12 @@ namespace nadena.dev.modular_avatar.core.editor
 
         protected override void OnInnerInspectorGUI()
         {
-            ElementHeightCache = BuildHeightCache();
-
             EditorGUI.BeginChangeCheck();
             _devMode = EditorGUILayout.Toggle(G("params.devmode"), _devMode);
             if (EditorGUI.EndChangeCheck() || _reorderableList == null || _needsRebuild) SetupList();
             Debug.Assert(_reorderableList != null, nameof(_reorderableList) + " != null");
+            
+            ElementHeightCache = BuildHeightCache();
 
             if (_devMode || _selectedIndices.Count > 0)
             {


### PR DESCRIPTION
Fix #333 

パラメータを削除した際、 `AvatarParametersEditor.OnInnerInspectorGUI()` の `BuildHeightCache` で未更新の_selectedIndicesを見るためout of boundsが発生しています。
ReorderableListの描画までにElementHeightCacheを更新出来ればよいと思われるため、SetupList()が叩かれた後に移動しました。