### PR TITLE
chore: remove meta file for empty folder

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/Menu/ActionProcessing.meta
+++ b/Packages/nadena.dev.modular-avatar/Editor/Menu/ActionProcessing.meta
@@ -1,4 +1,0 @@
-﻿fileFormatVersion: 2
-guid: d1cf0a36e200446cb099ec448b446495
-timeCreated: 1677334996
-folderAsset: yes


### PR DESCRIPTION
empty folders are not tracked by git so such a meta file will be removed by unity on loading