### PR TITLE
 ボーンが存在しないSkinnedMeshRendererでRootBoneを設定すると描画位置がずれる問題の修正

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/MeshSettingsPass.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/MeshSettingsPass.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Linq;
+using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -102,6 +103,17 @@ namespace nadena.dev.modular_avatar.core.editor
 
             if (settings.SetBounds && mesh is SkinnedMeshRenderer smr)
             {
+                if (smr.bones.Length == 0)
+                {
+                    Mesh newMesh = Object.Instantiate(smr.sharedMesh);
+                    smr.sharedMesh = newMesh;
+                    smr.bones = new Transform[] { smr.transform };
+                    smr.rootBone = smr.transform;
+                    smr.sharedMesh.boneWeights = Enumerable.Repeat(new BoneWeight() { boneIndex0 = 0, weight0 = 1 }, newMesh.vertexCount).ToArray();
+                    smr.sharedMesh.bindposes = new Matrix4x4[] { smr.transform.worldToLocalMatrix * smr.transform.localToWorldMatrix };
+
+                    if (newMesh) context.SaveAsset(newMesh);
+                }
                 smr.rootBone = settings.RootBone;
                 smr.localBounds = settings.Bounds;
             }

--- a/Packages/nadena.dev.modular-avatar/Editor/MeshSettingsPass.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/MeshSettingsPass.cs
@@ -103,7 +103,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
             if (settings.SetBounds && mesh is SkinnedMeshRenderer smr)
             {
-                if (smr.bones.Length == 0)
+                if (smr.bones.Length == 0 && smr.sharedMesh)
                 {
                     Mesh newMesh = Object.Instantiate(smr.sharedMesh);
                     smr.sharedMesh = newMesh;


### PR DESCRIPTION
ArmatureやBoneがない状態のSkinnedMeshRendererにRootBoneを指定すると、描画位置がRootBoneの場所へ移動してしまう問題の修正です。
自身のTransformをボーンとして登録したメッシュを生成する事で対策を行いました。