### PR TITLE
fix: issues with multiple installers using the same expressions menu asset

### DIFF
--- a/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParamTestMenu.asset
+++ b/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParamTestMenu.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -340790334, guid: 67cc4cb7839cd3741b63733d5adf0442, type: 3}
+  m_Name: InternalParamTestMenu
+  m_EditorClassIdentifier: 
+  controls:
+  - name: item
+    icon: {fileID: 0}
+    type: 102
+    parameter:
+      name: x
+    value: 1
+    style: 0
+    subMenu: {fileID: 0}
+    subParameters: []
+    labels: []

--- a/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParamTestMenu.asset.meta
+++ b/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParamTestMenu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09a6ec3c61c7db840b3cd958099c5798
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParameterTest.prefab
+++ b/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParameterTest.prefab
@@ -1,0 +1,450 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2860324038786842778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2860324038786842773}
+  - component: {fileID: 2860324038786842772}
+  - component: {fileID: 1761937879440307670}
+  - component: {fileID: 3202484316900348122}
+  - component: {fileID: 2669963860607714920}
+  - component: {fileID: 5085570563562387984}
+  m_Layer: 0
+  m_Name: InternalParameterTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2860324038786842773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_LocalRotation: {x: 0.07681167, y: 0.62035006, z: 0.20221491, w: 0.7539065}
+  m_LocalPosition: {x: -0.0534066, y: 0.9950551, z: 0.14142857}
+  m_LocalScale: {x: 1.098901, y: 1.0989009, z: 1.098901}
+  m_Children:
+  - {fileID: 8910535925068494434}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2860324038786842772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71a96d4ea0c344f39e277d82035bf9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parameters:
+  - nameOrPrefix: x
+    remapTo: 
+    internalParameter: 1
+    isPrefix: 0
+    syncType: 3
+    localOnly: 0
+    defaultValue: 0
+    saved: 1
+--- !u!114 &1761937879440307670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b29d45007c5493d926d2cd45a489529, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Control:
+    name: 
+    icon: {fileID: 0}
+    type: 103
+    parameter:
+      name: 
+    value: 1
+    style: 0
+    subMenu: {fileID: 11400000, guid: 09a6ec3c61c7db840b3cd958099c5798, type: 2}
+    subParameters: []
+    labels: []
+  MenuSource: 0
+  menuSource_otherObjectChildren: {fileID: 0}
+  isSynced: 1
+  isSaved: 1
+--- !u!114 &3202484316900348122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ef83cb0c23d4d7c9d41021e544a1978, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  menuToAppend: {fileID: 11400000, guid: 09a6ec3c61c7db840b3cd958099c5798, type: 2}
+  installTargetMenu: {fileID: 0}
+--- !u!114 &2669963860607714920
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 542108242, guid: 67cc4cb7839cd3741b63733d5adf0442, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: 
+  ViewPosition: {x: 0, y: 1.6, z: 0.2}
+  Animations: 0
+  ScaleIPD: 1
+  lipSync: 0
+  lipSyncJawBone: {fileID: 0}
+  lipSyncJawClosed: {x: 0, y: 0, z: 0, w: 1}
+  lipSyncJawOpen: {x: 0, y: 0, z: 0, w: 1}
+  VisemeSkinnedMesh: {fileID: 0}
+  MouthOpenBlendShapeName: Facial_Blends.Jaw_Down
+  VisemeBlendShapes: []
+  unityVersion: 
+  portraitCameraPositionOffset: {x: 0, y: 0, z: 0}
+  portraitCameraRotationOffset: {x: 0, y: 1, z: 0, w: -0.00000004371139}
+  networkIDs: []
+  customExpressions: 0
+  expressionsMenu: {fileID: 0}
+  expressionParameters: {fileID: 0}
+  enableEyeLook: 0
+  customEyeLookSettings:
+    eyeMovement:
+      confidence: 0.5
+      excitement: 0.5
+    leftEye: {fileID: 0}
+    rightEye: {fileID: 0}
+    eyesLookingStraight:
+      linked: 1
+      left: {x: 0, y: 0, z: 0, w: 0}
+      right: {x: 0, y: 0, z: 0, w: 0}
+    eyesLookingUp:
+      linked: 1
+      left: {x: 0, y: 0, z: 0, w: 0}
+      right: {x: 0, y: 0, z: 0, w: 0}
+    eyesLookingDown:
+      linked: 1
+      left: {x: 0, y: 0, z: 0, w: 0}
+      right: {x: 0, y: 0, z: 0, w: 0}
+    eyesLookingLeft:
+      linked: 1
+      left: {x: 0, y: 0, z: 0, w: 0}
+      right: {x: 0, y: 0, z: 0, w: 0}
+    eyesLookingRight:
+      linked: 1
+      left: {x: 0, y: 0, z: 0, w: 0}
+      right: {x: 0, y: 0, z: 0, w: 0}
+    eyelidType: 0
+    upperLeftEyelid: {fileID: 0}
+    upperRightEyelid: {fileID: 0}
+    lowerLeftEyelid: {fileID: 0}
+    lowerRightEyelid: {fileID: 0}
+    eyelidsDefault:
+      upper:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+      lower:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+    eyelidsClosed:
+      upper:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+      lower:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+    eyelidsLookingUp:
+      upper:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+      lower:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+    eyelidsLookingDown:
+      upper:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+      lower:
+        linked: 1
+        left: {x: 0, y: 0, z: 0, w: 0}
+        right: {x: 0, y: 0, z: 0, w: 0}
+    eyelidsSkinnedMesh: {fileID: 0}
+    eyelidsBlendshapes: 
+  customizeAnimationLayers: 0
+  baseAnimationLayers:
+  - isEnabled: 0
+    type: 0
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 2
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 3
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 4
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 5
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  specialAnimationLayers:
+  - isEnabled: 0
+    type: 6
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 7
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  - isEnabled: 0
+    type: 8
+    animatorController: {fileID: 0}
+    mask: {fileID: 0}
+    isDefault: 1
+  AnimationPreset: {fileID: 0}
+  animationHashSet: []
+  autoFootsteps: 1
+  autoLocomotion: 1
+  collider_head:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_torso:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_footR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_footL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_handR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_handL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerIndexL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerMiddleL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerRingL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerLittleL:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerIndexR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerMiddleR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerRingR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+  collider_fingerLittleR:
+    isMirrored: 1
+    state: 0
+    transform: {fileID: 0}
+    radius: 0
+    height: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0, w: 1}
+--- !u!114 &5085570563562387984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2860324038786842778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1427037861, guid: 4ecd63eff847044b68db9453ce219299, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  launchedFromSDKPipeline: 0
+  completedSDKPipeline: 0
+  blueprintId: 
+  contentType: 0
+  assetBundleUnityVersion: 
+  fallbackStatus: 0
+--- !u!1 &7624042284818776979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8910535925068494434}
+  - component: {fileID: 2708762870899574912}
+  - component: {fileID: 216941358938488416}
+  m_Layer: 0
+  m_Name: Menu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8910535925068494434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624042284818776979}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2860324038786842773}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2708762870899574912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624042284818776979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b29d45007c5493d926d2cd45a489529, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Control:
+    name: 
+    icon: {fileID: 0}
+    type: 103
+    parameter:
+      name: 
+    value: 1
+    style: 0
+    subMenu: {fileID: 0}
+    subParameters: []
+    labels: []
+  MenuSource: 0
+  menuSource_otherObjectChildren: {fileID: 0}
+  isSynced: 1
+  isSaved: 1
+--- !u!114 &216941358938488416
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624042284818776979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ef83cb0c23d4d7c9d41021e544a1978, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  menuToAppend: {fileID: 0}
+  installTargetMenu: {fileID: 0}

--- a/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParameterTest.prefab.meta
+++ b/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/InternalParameterTest.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15cecd8ca5178eb40953a581734e61f6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/VirtualMenuTests.cs
+++ b/Assets/_ModularAvatar/EditModeTests/VirtualMenuTests/VirtualMenuTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.modular_avatar.core.editor;
@@ -10,6 +11,8 @@ using UnityEditor.VersionControl;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
+using Object = UnityEngine.Object;
+using Random = UnityEngine.Random;
 
 namespace modular_avatar_tests.VirtualMenuTests
 {
@@ -76,9 +79,9 @@ namespace modular_avatar_tests.VirtualMenuTests
             virtualMenu.FreezeMenu();
 
             Assert.AreEqual(1, virtualMenu.ResolvedMenu.Count);
-            var root = virtualMenu.ResolvedMenu[rootMenu];
+            var root = virtualMenu.NodeForMenuAsset(rootMenu);
             Assert.AreEqual(2, root.Controls.Count);
-            Assert.AreSame(rootMenu, root.NodeKey);
+            Assert.AreSame(rootMenu, root.SourceMenu());
             AssertControlEquals(rootMenu.controls[0], root.Controls[0]);
             AssertControlEquals(rootMenu.controls[1], root.Controls[1]);
         }
@@ -109,22 +112,22 @@ namespace modular_avatar_tests.VirtualMenuTests
             virtualMenu.FreezeMenu();
 
             Assert.AreEqual(3, virtualMenu.ResolvedMenu.Count);
-            var rootNode = virtualMenu.ResolvedMenu[rootMenu];
-            var sub1Node = virtualMenu.ResolvedMenu[sub1];
-            var sub2Node = virtualMenu.ResolvedMenu[sub2];
+            var rootNode = virtualMenu.ResolvedMenu[virtualMenu.RootMenuKey];
+            var sub1Node = virtualMenu.NodeForMenuAsset(sub1);
+            var sub2Node = virtualMenu.NodeForMenuAsset(sub2);
 
             Assert.AreEqual(1, rootNode.Controls.Count);
-            Assert.AreSame(rootMenu, rootNode.NodeKey);
+            Assert.AreSame(virtualMenu.RootMenuKey, rootNode.NodeKey);
             Assert.AreSame(sub1Node, rootNode.Controls[0].SubmenuNode);
             Assert.IsNull(rootNode.Controls[0].subMenu);
 
             Assert.AreEqual(1, sub1Node.Controls.Count);
-            Assert.AreSame(sub1, sub1Node.NodeKey);
+            Assert.AreSame(sub1, sub1Node.SourceMenu());
             Assert.AreSame(sub2Node, sub1Node.Controls[0].SubmenuNode);
             Assert.IsNull(sub1Node.Controls[0].subMenu);
 
             Assert.AreEqual(1, sub2Node.Controls.Count);
-            Assert.AreSame(sub2, sub2Node.NodeKey);
+            Assert.AreSame(sub2, sub2Node.SourceMenu());
             Assert.AreSame(rootNode, sub2Node.Controls[0].SubmenuNode);
             Assert.IsNull(sub2Node.Controls[0].subMenu);
         }
@@ -246,10 +249,10 @@ namespace modular_avatar_tests.VirtualMenuTests
 
             Assert.AreEqual(2, virtualMenu.ResolvedMenu.Count);
             var rootMenu = virtualMenu.ResolvedMenu[RootMenu.Instance];
-            var subMenu = virtualMenu.ResolvedMenu[menu_b];
+            var subMenu = virtualMenu.NodeForMenuAsset(menu_b);
             Assert.AreSame(subMenu, rootMenu.Controls[0].SubmenuNode);
             Assert.AreSame(RootMenu.Instance, rootMenu.NodeKey);
-            Assert.AreSame(menu_b, subMenu.NodeKey);
+            Assert.AreSame(menu_b, ((ValueTuple<object, object>) subMenu.NodeKey).Item1);
             Assert.AreEqual(1, subMenu.Controls.Count);
             AssertControlEquals(menu_b.controls[0], subMenu.Controls[0]);
         }
@@ -327,8 +330,7 @@ namespace modular_avatar_tests.VirtualMenuTests
             virtualMenu.FreezeMenu();
 
             Assert.AreEqual(1, virtualMenu.ResolvedMenu.Count);
-            var rootMenu = virtualMenu.ResolvedMenu[menu_a];
-            var menu_a_node = virtualMenu.ResolvedMenu[menu_a];
+            var rootMenu = virtualMenu.NodeForMenuAsset(menu_a);
             Assert.AreEqual(3, rootMenu.Controls.Count);
         }
 
@@ -560,7 +562,7 @@ namespace modular_avatar_tests.VirtualMenuTests
 
             virtualMenu.FreezeMenu();
 
-            var root = virtualMenu.ResolvedMenu[menu_a];
+            var root = virtualMenu.NodeForMenuAsset(menu_a);
             Assert.AreEqual(1, root.Controls.Count);
         }
 
@@ -654,6 +656,19 @@ namespace modular_avatar_tests.VirtualMenuTests
             ));
         }
 
+        [Test]
+        public void internalParameterTest()
+        {
+            var root = CreatePrefab("InternalParameterTest.prefab");
+
+            BuildContext buildContext = new BuildContext(root.GetComponent<VRCAvatarDescriptor>());
+            new RenameParametersHook().OnPreprocessAvatar(root, buildContext);
+            var virtualMenu = VirtualMenu.ForAvatar(root.GetComponent<VRCAvatarDescriptor>(), buildContext);
+
+            Assert.AreNotEqual("x", virtualMenu.RootMenuNode.Controls[0]
+                .SubmenuNode.Controls[0].parameter.name);
+        }
+
         ModularAvatarMenuInstaller CreateInstaller(string name)
         {
             GameObject obj = new GameObject();
@@ -731,6 +746,26 @@ namespace modular_avatar_tests.VirtualMenuTests
             Assert.AreNotSame(expected.subParameters[0], actual.subParameters[0]);
             Assert.AreEqual(expected.value, actual.value);
             Assert.AreEqual(expected.style, actual.style);
+        }
+    }
+
+    internal static class TestHelpers
+    {
+        internal static VirtualMenuNode NodeForMenuAsset(this VirtualMenu menu, VRCExpressionsMenu asset)
+        {
+            return menu.ResolvedMenu.FirstOrDefault(
+                kvp => kvp.Key is ValueTuple<object, object> tuple && ReferenceEquals(tuple.Item1, asset)
+            ).Value;
+        }
+
+        internal static VRCExpressionsMenu SourceMenu(this VirtualMenuNode node)
+        {
+            if (node.NodeKey is ValueTuple<object, object> tuple && tuple.Item1 is VRCExpressionsMenu menu)
+            {
+                return menu;
+            }
+
+            return null;
         }
     }
 }

--- a/Packages/nadena.dev.modular-avatar/Editor/Inspector/Menu/MenuPreviewGUI.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/Inspector/Menu/MenuPreviewGUI.cs
@@ -107,7 +107,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public void DoGUI(VRCExpressionsMenu menu, GameObject parameterReference = null)
         {
-            new VisitorContext(this).PushNode(menu);
+            new VisitorContext(this).PushMenuContents(menu);
         }
 
         private void PushGuiNode(object key, Func<Action> guiBuilder)
@@ -162,7 +162,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 });
             }
 
-            public void PushNode(VRCExpressionsMenu expMenu)
+            public void PushMenuContents(VRCExpressionsMenu expMenu)
             {
                 PushMenu(expMenu, null);
             }

--- a/Packages/nadena.dev.modular-avatar/Runtime/Menu/VirtualMenuAPI.cs
+++ b/Packages/nadena.dev.modular-avatar/Runtime/Menu/VirtualMenuAPI.cs
@@ -106,7 +106,7 @@ namespace nadena.dev.modular_avatar.core.menu
         /// installer invocations.
         /// </summary>
         /// <param name="expMenu"></param>
-        void PushNode(VRCExpressionsMenu expMenu);
+        void PushMenuContents(VRCExpressionsMenu expMenu);
 
         /// <summary>
         /// Pushes the contents of this menu source onto the current menu node.


### PR DESCRIPTION
- chore: adding unit tests for #366 and #326
- fix: duplicate submenu controls not generated for multiple installers
- fix: submenus incorrectly deduping across different postprocessing contexts
