### PR TITLE
fix: add  a heuristic bone mapping

### DIFF
--- a/Packages/nadena.dev.modular-avatar/Editor/HeuristicBoneMapper.cs
+++ b/Packages/nadena.dev.modular-avatar/Editor/HeuristicBoneMapper.cs
@@ -41,7 +41,7 @@ namespace nadena.dev.modular_avatar.core.editor
             new[] {"LeftFoot", "Foot_Left", "Foot_L", "Ankle_L", "Foot.L.001", "Left ankle", "heel.L", "heel"},
             new[] {"RightFoot", "Foot_Right", "Foot_R", "Ankle_R", "Foot.R.001", "Right ankle", "heel.R", "heel"},
             new[] {"Spine"},
-            new[] {"Chest", "Bust"},
+            new[] {"Chest", "Bust", "Chest 1"},
             new[] {"Neck"},
             new[] {"Head"},
             new[] {"LeftShoulder", "Shoulder_Left", "Shoulder_L"},


### PR DESCRIPTION
https://booth.pm/ja/items/3803368 のChestボーン名が"Chest 1"となっていることで、ボーン名の統合ができず正しくMerge ArmatureができないことのWorkaroundです