### PR TITLE
chore: fix SceneManagement editor using

### DIFF
--- a/Editor/Inspector/InspectorCommon.cs
+++ b/Editor/Inspector/InspectorCommon.cs
@@ -1,5 +1,11 @@
 ﻿using UnityEditor;
+
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.SceneManagement;
+#else
 using UnityEditor.Experimental.SceneManagement;
+#endif
+
 using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core.editor


### PR DESCRIPTION
Related issue: #478

[PrefabStageUtility](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/SceneManagement.PrefabStageUtility.html) is no longer [Experimental](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Experimental.SceneManagement.PrefabStageUtility.html) on Unity 2021.2 and above