### PR TITLE
fix: null reference errors when apply on play triggers late

### DIFF
--- a/Runtime/ModularAvatarMergeArmature.cs
+++ b/Runtime/ModularAvatarMergeArmature.cs
@@ -131,6 +131,8 @@ namespace nadena.dev.modular_avatar.core
 
         private List<(Transform, Transform)> GetBonesForLock()
         {
+            if (this == null) return null;
+            
             var mergeRoot = this.transform;
             var baseRoot = mergeTarget.Get(this);
 


### PR DESCRIPTION
When an avatar is enabled after the scene is initially loaded, Merge Armature
would result in a lot of NullReferenceExceptions being logged.
