### PR TITLE
add missing meta files

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd88882c757966b4fa90915edb8487b1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d8d9b4fb0a3931b428757628a49d2567
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
when importing through a UPM registry like OpenUPM packages are immutable. So they should have all meta files included
![image](https://github.com/bdunderscore/modular-avatar/assets/31988415/49996fd1-9ffb-4fa9-9de1-59ddd3712868)

