### PR TITLE
fix: Visible Head Accessory processing is effective when building for Quest standalone

### DIFF
--- a/Editor/VisibleHeadAccessoryProcessor.cs
+++ b/Editor/VisibleHeadAccessoryProcessor.cs
@@ -80,6 +80,13 @@ namespace nadena.dev.modular_avatar.core.editor
 
         bool Process(ModularAvatarVisibleHeadAccessory target)
         {
+#if UNITY_ANDROID
+            foreach (var target in _avatar.GetComponentsInChildren<ModularAvatarVisibleHeadAccessory>(true))
+            {
+                Object.DestroyImmediate(target);
+            }
+            return;
+#endif
             bool didWork = false;
 
             if (Validate(target) == ReadyStatus.Ready)


### PR DESCRIPTION
#513 に対するパッチで、#if を使ったものですが#if を使用したくない場合であれば、[UnityEditorのAPI](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/EditorUserBuildSettings-activeBuildTarget.html) などがありそうなので、その場合はこの pull request はクローズしてください。

