### PR TITLE
Refactor: Delete unused code for MAAssetBundle generation

### DIFF
--- a/Editor/Util.cs
+++ b/Editor/Util.cs
@@ -25,7 +25,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using JetBrains.Annotations;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
@@ -34,24 +33,9 @@ using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
-    internal class CleanupTempAssets : IVRCSDKPostprocessAvatarCallback
-    {
-        public int callbackOrder => 99999;
-
-        public void OnPostprocessAvatar()
-        {
-            Util.DeleteTemporaryAssets();
-        }
-    }
-
     [InitializeOnLoad]
     internal static class Util
     {
-        private const string generatedAssetsSubdirectory = "999_Modular_Avatar_Generated";
-        private const string generatedAssetsPath = "Assets/" + generatedAssetsSubdirectory;
-
-        [CanBeNull] public static string OverridePath;
-
         static Util()
         {
             RuntimeUtil.delayCall = (cb) => EditorApplication.delayCall += cb.Invoke;
@@ -151,42 +135,6 @@ namespace nadena.dev.modular_avatar.core.editor
             var component = self.GetComponent<T>();
             if (component == null) component = self.AddComponent<T>();
             return component;
-        }
-
-        public static string GenerateAssetPath()
-        {
-            return GetGeneratedAssetsFolder() + "/" + GUID.Generate() + ".asset";
-        }
-
-        private static string GetGeneratedAssetsFolder()
-        {
-            var path = OverridePath ?? generatedAssetsPath;
-
-            var pathParts = path.Split('/');
-
-            for (int i = 1; i < pathParts.Length; i++)
-            {
-                var subPath = string.Join("/", pathParts, 0, i + 1);
-                if (!AssetDatabase.IsValidFolder(subPath))
-                {
-                    AssetDatabase.CreateFolder(string.Join("/", pathParts, 0, i), pathParts[i]);
-                }
-            }
-
-            return path;
-        }
-
-        internal static void DeleteTemporaryAssets()
-        {
-            EditorApplication.delayCall += () =>
-            {
-                AssetDatabase.SaveAssets();
-
-                var subdir = generatedAssetsPath;
-
-                AssetDatabase.DeleteAsset(subdir);
-                FileUtil.DeleteFileOrDirectory(subdir);
-            };
         }
 
         public static Type FindType(string typeName)

--- a/UnitTests~/TestBase.cs
+++ b/UnitTests~/TestBase.cs
@@ -48,7 +48,8 @@ namespace modular_avatar_tests
                 Object.DestroyImmediate(obj);
             }
 
-            Util.DeleteTemporaryAssets();
+            AssetDatabase.DeleteAsset(TEMP_ASSET_PATH);
+            FileUtil.DeleteFileOrDirectory(TEMP_ASSET_PATH);
         }
 
         protected nadena.dev.ndmf.BuildContext CreateContext(GameObject root)


### PR DESCRIPTION
Context: https://github.com/bdunderscore/modular-avatar/pull/504#discussion_r1378615896

Simple cleaning up old code.

Did not remove `MAAssetBundle` and editor for now, changing it into subclass of `ndmf.runtime.GeneratedAssets` was more aggressive choice (which would delete more code).