### PR TITLE
fix: missing physbone parameter suffixes

### DIFF
--- a/Editor/ParameterPolicy.cs
+++ b/Editor/ParameterPolicy.cs
@@ -56,6 +56,8 @@ namespace nadena.dev.modular_avatar.core.editor
             "_IsGrabbed",
             "_Angle",
             "_Stretch",
+            "_IsPosed",
+            "_Squish",
         }.ToImmutableList();
 
         public static ImmutableDictionary<string, DetectedParameter> ProbeParameters(GameObject root)


### PR DESCRIPTION
## Problem

Some Physbone parameters are not recognized in MA Parameters, this cause internal parameter don't work those parameters, such as _IsPosed.

![image](https://github.com/bdunderscore/modular-avatar/assets/149926927/33785c15-0c0f-46b8-8d1b-8a2a48d67727)

### Reproduction steps
1. Create PhysBone Component and set parameter `param`
2. Create FXLayer and Add Parameter `param_IsPosed` and `param_Stretch`
3. Setup Modular Avatar, Merge Animator / MA Parameters
4. Switch to MA Parameters Developer mode, `param` is recognized PhysBones Prefix, but also detected `param_IsPosed` with no PhysBones Prefix.