### PR TITLE
docs(world-fixed-object): fix description for Quest

### DIFF
--- a/docs~/docs/reference/world-fixed-object.md
+++ b/docs~/docs/reference/world-fixed-object.md
@@ -18,4 +18,4 @@ to its child. You can control the position of GameObjects within a World Fixed O
 Only one constraint will be generated, even if multiple World Fixed Object components are used.
 As such, the performance impact of this component is the same whether you use one or dozens.
 
-Due to technical limitations on the Quest, this component has no effect when building for Quest standalone.
+Due to technical limitations on the Quest, this component can't be used when building for Quest standalone.

--- a/docs~/i18n/ja/docusaurus-plugin-content-docs/current/reference/world-fixed-object.md
+++ b/docs~/i18n/ja/docusaurus-plugin-content-docs/current/reference/world-fixed-object.md
@@ -17,4 +17,4 @@ World Fixed ObjectのついたGameObjectはParent Constraint等を使用して�
 
 複数のWorld Fixed Objectコンポーネントを使っても、Constraintは一つだけです。なので、複数のGameObjectを指定しても、その分重くなることはありません。
 
-技術的な制約により、Quest単体では動作できません。Quest向けのビルドはつけたままにしてもいいが、効果は発揮しません。
+技術的な制約により、Quest単体では動作できず、Quest向けのビルドでは使用できません。


### PR DESCRIPTION
現状はWorld Fixed ObjectをQuest向けビルドでは使用できないため(#581)、実際の動作に合わせてドキュメントを更新します。