### PR TITLE
Add MA Merge VRM1 SpringBones

### DIFF
--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -128,6 +128,8 @@ namespace nadena.dev.modular_avatar.animation
 #if MA_VRCSDK3_AVATARS
             var avatarDescriptor = context.AvatarDescriptor;
 
+            if (!avatarDescriptor) return;
+
             foreach (var layer in avatarDescriptor.baseAnimationLayers)
             {
                 BootstrapLayer(layer);

--- a/Editor/Animation/AnimationUtil.cs
+++ b/Editor/Animation/AnimationUtil.cs
@@ -51,9 +51,12 @@ namespace nadena.dev.modular_avatar.animation
             // This helps reduce the risk that we'll accidentally modify the original assets.
 
 #if MA_VRCSDK3_AVATARS
-            context.AvatarDescriptor.baseAnimationLayers =
+            var avatarDescriptor = context.AvatarDescriptor;
+            if (!avatarDescriptor) return;
+
+            avatarDescriptor.baseAnimationLayers =
                 CloneLayers(context, context.AvatarDescriptor.baseAnimationLayers);
-            context.AvatarDescriptor.specialAnimationLayers =
+            avatarDescriptor.specialAnimationLayers =
                 CloneLayers(context, context.AvatarDescriptor.specialAnimationLayers);
 #endif
         }

--- a/Editor/FixupPasses/FixupExpressionsMenuPass.cs
+++ b/Editor/FixupPasses/FixupExpressionsMenuPass.cs
@@ -19,6 +19,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal static void FixupExpressionsMenu(BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             context.AvatarDescriptor.customExpressions = true;
 
             var expressionsMenu = context.AvatarDescriptor.expressionsMenu;

--- a/Editor/Inspector/VRM.meta
+++ b/Editor/Inspector/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 06db78df8bfa43faa5e0cb4f4fda5be0
+timeCreated: 1703897163

--- a/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs
+++ b/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs
@@ -2,6 +2,7 @@
 
 using nadena.dev.modular_avatar.core.vrm;
 using UnityEditor;
+using static nadena.dev.modular_avatar.core.editor.Localization;
 
 namespace nadena.dev.modular_avatar.core.editor.vrm
 {
@@ -19,10 +20,10 @@ namespace nadena.dev.modular_avatar.core.editor.vrm
         
         protected override void OnInnerInspectorGUI()
         {
-            EditorGUILayout.PropertyField(_prop_collider_groups);
-            EditorGUILayout.PropertyField(_prop_springs);
+            EditorGUILayout.PropertyField(_prop_collider_groups, G("merge_vrm1_spring_bones.collider_groups"));
+            EditorGUILayout.PropertyField(_prop_springs, G("merge_vrm1_spring_bones.springs"));
             serializedObject.ApplyModifiedProperties();
-            Localization.ShowLanguageUI();
+            ShowLanguageUI();
         }
     }
 }

--- a/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs
+++ b/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs
@@ -1,0 +1,30 @@
+﻿#if MA_VRM1
+
+using nadena.dev.modular_avatar.core.vrm;
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    [CustomEditor(typeof(ModularAvatarMergeVRM1SpringBones))]
+    internal class MergeVRM1SpringBonesEditor : MAEditorBase
+    {
+        private SerializedProperty _prop_collider_groups;
+        private SerializedProperty _prop_springs;
+
+        private void OnEnable()
+        {
+            _prop_collider_groups = serializedObject.FindProperty(nameof(ModularAvatarMergeVRM1SpringBones.colliderGroups));
+            _prop_springs = serializedObject.FindProperty(nameof(ModularAvatarMergeVRM1SpringBones.springs));
+        }
+        
+        protected override void OnInnerInspectorGUI()
+        {
+            EditorGUILayout.PropertyField(_prop_collider_groups);
+            EditorGUILayout.PropertyField(_prop_springs);
+            serializedObject.ApplyModifiedProperties();
+            Localization.ShowLanguageUI();
+        }
+    }
+}
+
+#endif

--- a/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs.meta
+++ b/Editor/Inspector/VRM/MergeVRM1SpringBonesEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11e938e54d3941f49524a8d438f86d12
+timeCreated: 1703897170

--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -95,6 +95,8 @@
   "merge_blend_tree.path_mode.tooltip": "How to interpret paths in animations. Using relative mode lets you record animations from an animator on this object.",
   "merge_blend_tree.relative_path_root": "Relative Path Root",
   "merge_blend_tree.relative_path_root.tooltip": "The root object to use when interpreting relative paths. If not specified, the object this component is attached to will be used.",
+  "merge_vrm1_spring_bones.collider_groups": "Collider Groups",
+  "merge_vrm1_spring_bones.springs": "Springs",
   "worldfixed.quest": "This component is not compatible with Android builds and will have no effect.",
   "worldfixed.normal": "This object will be fixed to world unless you fixed to avatar with constraint.",
   "fpvisible.normal": "This object will be visible in your first person view.",

--- a/Editor/MergeAnimatorProcessor.cs
+++ b/Editor/MergeAnimatorProcessor.cs
@@ -65,6 +65,7 @@ namespace nadena.dev.modular_avatar.core.editor
             mergeSessions.Clear();
 
             var descriptor = avatarGameObject.GetComponent<VRCAvatarDescriptor>();
+            if (!descriptor) return;
 
             if (descriptor.baseAnimationLayers != null) InitSessions(descriptor.baseAnimationLayers);
             if (descriptor.specialAnimationLayers != null) InitSessions(descriptor.specialAnimationLayers);

--- a/Editor/MergeArmatureHook.cs
+++ b/Editor/MergeArmatureHook.cs
@@ -36,6 +36,15 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
+
+#if MA_VRM0
+using VRM;
+#endif
+
+#if MA_VRM1
+using UniVRM10;
+#endif
+
 using Object = UnityEngine.Object;
 
 #endregion
@@ -105,6 +114,35 @@ namespace nadena.dev.modular_avatar.core.editor
             foreach (var c in avatarGameObject.transform.GetComponentsInChildren<ContactBase>(true))
             {
                 if (c.rootTransform == null) c.rootTransform = c.transform;
+                RetainBoneReferences(c);
+            }
+#endif
+
+#if MA_VRM0
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRMSpringBone>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRMSpringBoneColliderGroup>(true))
+            {
+                RetainBoneReferences(c);
+            }
+#endif
+
+#if MA_VRM1
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneJoint>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneCollider>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneColliderGroup>(true))
+            {
                 RetainBoneReferences(c);
             }
 #endif
@@ -477,5 +515,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 #endif
+
+        // TODO - deduplicate VRM0/1 SpringBone components... doesn't break avatars either
     }
 }

--- a/Editor/OptimizationPasses/GCGameObjectsPass.cs
+++ b/Editor/OptimizationPasses/GCGameObjectsPass.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 #endif
 
+#if MA_VRM0
+using VRM;
+#endif
+
 namespace nadena.dev.modular_avatar.core.editor
 {
     /// <summary>
@@ -63,6 +67,13 @@ namespace nadena.dev.modular_avatar.core.editor
                         case VRCPhysBone pb:
                             MarkObject(obj);
                             MarkPhysBone(pb);
+                            break;
+#endif
+
+#if MA_VRM0
+                        case VRMSpringBone sb:
+                            MarkObject(obj);
+                            MarkSpringBone(sb);
                             break;
 #endif
 
@@ -144,6 +155,22 @@ namespace nadena.dev.modular_avatar.core.editor
 
             // Mark colliders, etc
             MarkAllReferencedObjects(pb);
+        }
+#endif
+
+#if MA_VRM0
+        private void MarkSpringBone(VRMSpringBone sb)
+        {
+            foreach (var rootBone in sb.RootBones)
+            {
+                foreach (var obj in GameObjects(rootBone.gameObject))
+                {
+                    MarkObject(obj);
+                }
+            }
+
+            // Mark etc
+            MarkAllReferencedObjects(sb);
         }
 #endif
 

--- a/Editor/OptimizationPasses/PruneParametersPass.cs
+++ b/Editor/OptimizationPasses/PruneParametersPass.cs
@@ -9,6 +9,8 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             var expParams = context.AvatarDescriptor.expressionParameters;
             if (expParams != null && context.IsTemporaryAsset(expParams))
             {

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -12,6 +12,10 @@ using Object = UnityEngine.Object;
 
 #endregion
 
+#if MA_VRM0 || MA_VRM1
+using nadena.dev.modular_avatar.core.editor.vrm;
+#endif
+
 [assembly: ExportsPlugin(
     typeof(PluginDefinition)
 )]
@@ -57,6 +61,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                 seq.WithRequiredExtension(typeof(AnimationServicesContext), _s2 =>
                 {
                     seq.Run(MergeArmaturePluginPass.Instance);
+#if MA_VRM1
+                    seq.Run(MergeVRM1SpringBonesPass.Instance);
+#endif
                     seq.Run(BoneProxyPluginPass.Instance);
                     seq.Run(VisibleHeadAccessoryPluginPass.Instance);
                     seq.Run("World Fixed Object",
@@ -125,7 +132,7 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
         }
     }
 
-    abstract class MAPass<T> : Pass<T> where T : Pass<T>, new()
+    internal abstract class MAPass<T> : Pass<T> where T : Pass<T>, new()
     {
         protected BuildContext MAContext(ndmf.BuildContext context)
         {

--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -183,6 +183,8 @@ namespace nadena.dev.modular_avatar.core.editor
                 .ToImmutableDictionary();
             
             var avatar = avatarRoot.GetComponent<VRCAvatarDescriptor>();
+            if (!avatar) return;
+
             var expParams = avatar.expressionParameters;
 
             if (expParams == null)

--- a/Editor/VRM.meta
+++ b/Editor/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 08e5ba5bfc3246849b6babf1eb2b8f02
+timeCreated: 1697931783

--- a/Editor/VRM/MergeVRM1SpringBonesPass.cs
+++ b/Editor/VRM/MergeVRM1SpringBonesPass.cs
@@ -12,12 +12,12 @@ namespace nadena.dev.modular_avatar.core.editor.vrm
     {
         protected override void Execute(ndmf.BuildContext context)
         {
-            var processor = new MergeSpringBoneProcessor();
+            var processor = new MergeVRM1SpringBoneProcessor();
             processor.ProcessVRM1(context);
         }
     }
 
-    public class MergeSpringBoneProcessor
+    internal class MergeVRM1SpringBoneProcessor
     {
         public void ProcessVRM1(ndmf.BuildContext context)
         {

--- a/Editor/VRM/MergeVRM1SpringBonesPass.cs
+++ b/Editor/VRM/MergeVRM1SpringBonesPass.cs
@@ -1,0 +1,46 @@
+#if MA_VRM1
+
+using System.Linq;
+using nadena.dev.ndmf;
+using nadena.dev.modular_avatar.core.vrm;
+
+using UniVRM10;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    internal class MergeVRM1SpringBonesPass : Pass<MergeVRM1SpringBonesPass>
+    {
+        protected override void Execute(ndmf.BuildContext context)
+        {
+            var processor = new MergeSpringBoneProcessor();
+            processor.ProcessVRM1(context);
+        }
+    }
+
+    public class MergeSpringBoneProcessor
+    {
+        public void ProcessVRM1(ndmf.BuildContext context)
+        {
+            var rootTransform = context.AvatarRootObject;
+            var vrmInstance = rootTransform.GetComponent<Vrm10Instance>();
+            if (!vrmInstance) return;
+
+            var sources = rootTransform.GetComponentsInChildren<ModularAvatarMergeVRM1SpringBones>(); 
+
+            vrmInstance.SpringBone.ColliderGroups = vrmInstance.SpringBone.ColliderGroups
+                .Concat(sources.SelectMany(bone => bone.colliderGroups))
+                .ToList();
+            
+            vrmInstance.SpringBone.Springs = vrmInstance.SpringBone.Springs
+                .Concat(sources.SelectMany(bone => bone.springs))
+                .ToList();
+
+            foreach (var source in sources)
+            {
+                UnityEngine.Object.DestroyImmediate(source);
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/VRM/MergeVRM1SpringBonesPass.cs.meta
+++ b/Editor/VRM/MergeVRM1SpringBonesPass.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b8572923255d4c498a9f725b5659bfce
+timeCreated: 1697931793

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -6,7 +6,9 @@
         "VRC.SDK3A",
         "VRC.SDKBase",
         "nadena.dev.ndmf",
-        "nadena.dev.ndmf.vrchat"
+        "nadena.dev.ndmf.vrchat",
+        "VRM",
+        "VRM10"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -41,6 +41,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrmc.univrm",
+            "expression": "",
+            "define": "MA_VRM0"
+        },
+        {
+            "name": "com.vrmc.vrm",
+            "expression": "",
+            "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/VRM.meta
+++ b/Runtime/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e87fc31023354643907403ca7bb5c5fb
+timeCreated: 1697930873

--- a/Runtime/VRM/ModularAvatarMergeVRM1SpringBones.cs
+++ b/Runtime/VRM/ModularAvatarMergeVRM1SpringBones.cs
@@ -1,0 +1,18 @@
+#if MA_VRM1
+
+using System.Collections.Generic;
+using UnityEngine;
+using UniVRM10;
+
+namespace nadena.dev.modular_avatar.core.vrm
+{
+    [AddComponentMenu("Modular Avatar/MA Merge VRM1 SpringBones")]
+    [DisallowMultipleComponent]
+    public class ModularAvatarMergeVRM1SpringBones : AvatarTagComponent
+    {
+        public List<VRM10SpringBoneColliderGroup> colliderGroups = new List<VRM10SpringBoneColliderGroup>();
+        public List<Vrm10InstanceSpringBone.Spring> springs = new List<Vrm10InstanceSpringBone.Spring>();
+    }
+}
+
+#endif

--- a/Runtime/VRM/ModularAvatarMergeVRM1SpringBones.cs.meta
+++ b/Runtime/VRM/ModularAvatarMergeVRM1SpringBones.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94df312e949c457f8254f0a5c842d9f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: a8edd5bd1a0a64a40aa99cc09fb5f198, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/nadena.dev.modular-avatar.core.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.core.asmdef
@@ -24,6 +24,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrmc.univrm",
+            "expression": "",
+            "define": "MA_VRM0"
+        },
+        {
+            "name": "com.vrmc.vrm",
+            "expression": "",
+            "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/nadena.dev.modular-avatar.core.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.core.asmdef
@@ -3,7 +3,9 @@
     "rootNamespace": "",
     "references": [
         "Unity.Burst",
-        "nadena.dev.ndmf.runtime"
+        "nadena.dev.ndmf.runtime",
+        "VRM",
+        "VRM10"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UnitTests~/Tests.asmdef
+++ b/UnitTests~/Tests.asmdef
@@ -30,6 +30,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+          "name": "com.vrmc.univrm",
+          "expression": "",
+          "define": "MA_VRM0"
+        },
+        {
+          "name": "com.vrmc.vrm",
+          "expression": "",
+          "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Discussion: https://github.com/bdunderscore/modular-avatar/discussions/467
Merge base PR first: UniVRM components support #569

![image](https://github.com/bdunderscore/modular-avatar/assets/4142423/bc8aabc2-2d96-414c-a933-e053b4c371f4)

This PR introduces `MA Merge VRM1 SpringBones` component, which adds SpringBone entries to `VRM10Instance`.
This component does nothing when the target avatar is not VRM1.

I think there is nothing specific to this component that requires localization. Perhaps there could be some warning like "This component is ignored; supports VRM1 avatar only", but many other components that targets VRCSDK only have similar issue.

I have not yet added documents. Merging this PR reveals UniVRM support to end users, so documentation would block the next release once this PR is merged.
I don't know yet where to add documents. (It would be under `docs~/`, but I worry that throwing VRM specific components into the Component reference section makes little sense to VRC users, when the entire components list is even more growing).