### PR TITLE
Add MA Merge VRM0+1 FirstPerson

### DIFF
--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -128,6 +128,8 @@ namespace nadena.dev.modular_avatar.animation
 #if MA_VRCSDK3_AVATARS
             var avatarDescriptor = context.AvatarDescriptor;
 
+            if (!avatarDescriptor) return;
+
             foreach (var layer in avatarDescriptor.baseAnimationLayers)
             {
                 BootstrapLayer(layer);

--- a/Editor/Animation/AnimationUtil.cs
+++ b/Editor/Animation/AnimationUtil.cs
@@ -51,9 +51,12 @@ namespace nadena.dev.modular_avatar.animation
             // This helps reduce the risk that we'll accidentally modify the original assets.
 
 #if MA_VRCSDK3_AVATARS
-            context.AvatarDescriptor.baseAnimationLayers =
+            var avatarDescriptor = context.AvatarDescriptor;
+            if (!avatarDescriptor) return;
+
+            avatarDescriptor.baseAnimationLayers =
                 CloneLayers(context, context.AvatarDescriptor.baseAnimationLayers);
-            context.AvatarDescriptor.specialAnimationLayers =
+            avatarDescriptor.specialAnimationLayers =
                 CloneLayers(context, context.AvatarDescriptor.specialAnimationLayers);
 #endif
         }

--- a/Editor/FixupPasses/FixupExpressionsMenuPass.cs
+++ b/Editor/FixupPasses/FixupExpressionsMenuPass.cs
@@ -19,6 +19,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal static void FixupExpressionsMenu(BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             context.AvatarDescriptor.customExpressions = true;
 
             var expressionsMenu = context.AvatarDescriptor.expressionsMenu;

--- a/Editor/Inspector/VRM.meta
+++ b/Editor/Inspector/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 06db78df8bfa43faa5e0cb4f4fda5be0
+timeCreated: 1703897163

--- a/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs
+++ b/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs
@@ -1,0 +1,27 @@
+#if MA_VRM0 || MA_VRM1
+
+using nadena.dev.modular_avatar.core.vrm;
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    [CustomEditor(typeof(ModularAvatarMergeVRMFirstPerson))]
+    internal class MergeVRMFirstPersonEditor : MAEditorBase
+    {
+        private SerializedProperty _prop_renderers;
+
+        private void OnEnable()
+        {
+            _prop_renderers = serializedObject.FindProperty(nameof(ModularAvatarMergeVRMFirstPerson.renderers));
+        }
+        
+        protected override void OnInnerInspectorGUI()
+        {
+            EditorGUILayout.PropertyField(_prop_renderers);
+            serializedObject.ApplyModifiedProperties();
+            Localization.ShowLanguageUI();
+        }
+    }
+}
+
+#endif

--- a/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs
+++ b/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs
@@ -2,6 +2,7 @@
 
 using nadena.dev.modular_avatar.core.vrm;
 using UnityEditor;
+using static nadena.dev.modular_avatar.core.editor.Localization;
 
 namespace nadena.dev.modular_avatar.core.editor.vrm
 {
@@ -17,9 +18,9 @@ namespace nadena.dev.modular_avatar.core.editor.vrm
         
         protected override void OnInnerInspectorGUI()
         {
-            EditorGUILayout.PropertyField(_prop_renderers);
+            EditorGUILayout.PropertyField(_prop_renderers, G("merge_vrm_first_person.renderers"));
             serializedObject.ApplyModifiedProperties();
-            Localization.ShowLanguageUI();
+            ShowLanguageUI();
         }
     }
 }

--- a/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs.meta
+++ b/Editor/Inspector/VRM/MergeVRMFirstPersonEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 48aced3669be474097c8a1e597f4c91c
+timeCreated: 1703899571

--- a/Editor/Inspector/VRM/RendererFirstPersonFlagsDrawer.cs
+++ b/Editor/Inspector/VRM/RendererFirstPersonFlagsDrawer.cs
@@ -1,0 +1,30 @@
+#if MA_VRM0 || MA_VRM1
+
+using nadena.dev.modular_avatar.core.vrm;
+using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    [CustomPropertyDrawer(typeof(ModularAvatarMergeVRMFirstPerson.RendererFirstPersonFlags))]
+    internal class RendererFirstPersonFlagsDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var rendererProp = property.FindPropertyRelative(nameof(ModularAvatarMergeVRMFirstPerson.RendererFirstPersonFlags.renderer));
+            var flagProp = property.FindPropertyRelative(nameof(ModularAvatarMergeVRMFirstPerson.RendererFirstPersonFlags.firstPersonFlag));
+
+            const float rightSideWidth = 140.0f;
+
+            var leftSide = position;
+            leftSide.xMax -= rightSideWidth;
+            EditorGUI.PropertyField(leftSide, rendererProp, GUIContent.none);
+
+            var rightSide = position;
+            rightSide.xMin = rightSide.xMax - rightSideWidth;
+            EditorGUI.PropertyField(rightSide, flagProp, GUIContent.none);
+        }
+    }
+}
+
+#endif

--- a/Editor/Inspector/VRM/RendererFirstPersonFlagsDrawer.cs.meta
+++ b/Editor/Inspector/VRM/RendererFirstPersonFlagsDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 737daea49bf9487bbeebdebf6c0af015
+timeCreated: 1703904107

--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -95,6 +95,7 @@
   "merge_blend_tree.path_mode.tooltip": "How to interpret paths in animations. Using relative mode lets you record animations from an animator on this object.",
   "merge_blend_tree.relative_path_root": "Relative Path Root",
   "merge_blend_tree.relative_path_root.tooltip": "The root object to use when interpreting relative paths. If not specified, the object this component is attached to will be used.",
+  "merge_vrm_first_person.renderers": "Renderers",
   "worldfixed.quest": "This component is not compatible with Android builds and will have no effect.",
   "worldfixed.normal": "This object will be fixed to world unless you fixed to avatar with constraint.",
   "fpvisible.normal": "This object will be visible in your first person view.",

--- a/Editor/MergeAnimatorProcessor.cs
+++ b/Editor/MergeAnimatorProcessor.cs
@@ -65,6 +65,7 @@ namespace nadena.dev.modular_avatar.core.editor
             mergeSessions.Clear();
 
             var descriptor = avatarGameObject.GetComponent<VRCAvatarDescriptor>();
+            if (!descriptor) return;
 
             if (descriptor.baseAnimationLayers != null) InitSessions(descriptor.baseAnimationLayers);
             if (descriptor.specialAnimationLayers != null) InitSessions(descriptor.specialAnimationLayers);

--- a/Editor/MergeArmatureHook.cs
+++ b/Editor/MergeArmatureHook.cs
@@ -36,6 +36,15 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
+
+#if MA_VRM0
+using VRM;
+#endif
+
+#if MA_VRM1
+using UniVRM10;
+#endif
+
 using Object = UnityEngine.Object;
 
 #endregion
@@ -105,6 +114,35 @@ namespace nadena.dev.modular_avatar.core.editor
             foreach (var c in avatarGameObject.transform.GetComponentsInChildren<ContactBase>(true))
             {
                 if (c.rootTransform == null) c.rootTransform = c.transform;
+                RetainBoneReferences(c);
+            }
+#endif
+
+#if MA_VRM0
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRMSpringBone>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRMSpringBoneColliderGroup>(true))
+            {
+                RetainBoneReferences(c);
+            }
+#endif
+
+#if MA_VRM1
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneJoint>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneCollider>(true))
+            {
+                RetainBoneReferences(c);
+            }
+
+            foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRM10SpringBoneColliderGroup>(true))
+            {
                 RetainBoneReferences(c);
             }
 #endif
@@ -477,5 +515,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 #endif
+
+        // TODO - deduplicate VRM0/1 SpringBone components... doesn't break avatars either
     }
 }

--- a/Editor/OptimizationPasses/GCGameObjectsPass.cs
+++ b/Editor/OptimizationPasses/GCGameObjectsPass.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 #endif
 
+#if MA_VRM0
+using VRM;
+#endif
+
 namespace nadena.dev.modular_avatar.core.editor
 {
     /// <summary>
@@ -63,6 +67,13 @@ namespace nadena.dev.modular_avatar.core.editor
                         case VRCPhysBone pb:
                             MarkObject(obj);
                             MarkPhysBone(pb);
+                            break;
+#endif
+
+#if MA_VRM0
+                        case VRMSpringBone sb:
+                            MarkObject(obj);
+                            MarkSpringBone(sb);
                             break;
 #endif
 
@@ -144,6 +155,22 @@ namespace nadena.dev.modular_avatar.core.editor
 
             // Mark colliders, etc
             MarkAllReferencedObjects(pb);
+        }
+#endif
+
+#if MA_VRM0
+        private void MarkSpringBone(VRMSpringBone sb)
+        {
+            foreach (var rootBone in sb.RootBones)
+            {
+                foreach (var obj in GameObjects(rootBone.gameObject))
+                {
+                    MarkObject(obj);
+                }
+            }
+
+            // Mark etc
+            MarkAllReferencedObjects(sb);
         }
 #endif
 

--- a/Editor/OptimizationPasses/PruneParametersPass.cs
+++ b/Editor/OptimizationPasses/PruneParametersPass.cs
@@ -9,6 +9,8 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             var expParams = context.AvatarDescriptor.expressionParameters;
             if (expParams != null && context.IsTemporaryAsset(expParams))
             {

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -12,6 +12,10 @@ using Object = UnityEngine.Object;
 
 #endregion
 
+#if MA_VRM0 || MA_VRM1
+using nadena.dev.modular_avatar.core.editor.vrm;
+#endif
+
 [assembly: ExportsPlugin(
     typeof(PluginDefinition)
 )]
@@ -65,6 +69,12 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                     seq.Run(ReplaceObjectPluginPass.Instance);
 #if MA_VRCSDK3_AVATARS
                     seq.Run(BlendshapeSyncAnimationPluginPass.Instance);
+#endif
+#if MA_VRM0
+                    seq.Run(MergeVRM0FirstPersonPass.Instance);
+#endif
+#if MA_VRM1
+                    seq.Run(MergeVRM1FirstPersonPass.Instance);
 #endif
                 });
 #if MA_VRCSDK3_AVATARS

--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -183,6 +183,8 @@ namespace nadena.dev.modular_avatar.core.editor
                 .ToImmutableDictionary();
             
             var avatar = avatarRoot.GetComponent<VRCAvatarDescriptor>();
+            if (!avatar) return;
+
             var expParams = avatar.expressionParameters;
 
             if (expParams == null)

--- a/Editor/VRM.meta
+++ b/Editor/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 08e5ba5bfc3246849b6babf1eb2b8f02
+timeCreated: 1697931783

--- a/Editor/VRM/CustomClone.cs
+++ b/Editor/VRM/CustomClone.cs
@@ -1,0 +1,180 @@
+#if MA_VRM1
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    internal abstract class CustomClone<T, TOut>
+        where T : Object
+        where TOut : Object
+    {
+        CopyStrategyDescriptor _descriptor;
+
+        protected abstract void Define(CopyStrategyDescriptor descriptor);
+
+        [PublicAPI]
+        public (TOut mainAsset, IEnumerable<Object> subAssets) Clone(T source)
+        {
+            if (_descriptor == null)
+            {
+                _descriptor = new CopyStrategyDescriptor();
+                Define(_descriptor);                
+            }
+            
+            var context = new CustomCloneContext(_descriptor);
+            var mainAsset = context.CachedClone(source) as TOut;
+            var subAssets = context.Mapping.Values.Where(a => a != mainAsset).ToArray();
+            return (mainAsset, subAssets);
+        }
+
+        [PublicAPI]
+        public Object CloneAsNewAsset(T source, string assetPath)
+        {
+            var assets = Clone(source);
+            AssetDatabase.CreateAsset(assets.mainAsset, assetPath);
+            foreach (var subAsset in assets.subAssets)
+            {
+                AssetDatabase.AddObjectToAsset(subAsset, assets.mainAsset);
+                subAsset.hideFlags = HideFlags.None;
+            }
+            AssetDatabase.SaveAssets();
+            return assets.mainAsset;
+        }
+    }
+    
+    abstract class CustomClone<T> : CustomClone<T, T> where T : Object { }
+
+    class CustomCloneContext
+    {
+        readonly CopyStrategyDescriptor _descriptor;
+        public readonly Dictionary<Object, Object> Mapping = new Dictionary<Object, Object>();
+            
+        public CustomCloneContext(CopyStrategyDescriptor descriptor) => _descriptor = descriptor;
+
+        public Object CachedClone(Object source)
+        {
+            if (source is null) return default;
+
+            foreach (var copyStrategy in _descriptor.List)
+            {
+                if (copyStrategy.Match(source))
+                {
+                    return copyStrategy.GetCopy(source, this);
+                }
+            }
+            throw new CustomCloneException($"Unable to handle object <{source}> with type <{source.GetType()}>");
+        }
+    }
+
+    internal class CopyStrategyDescriptor
+    {
+        public List<ICopyStrategy> List { get; } = new List<ICopyStrategy>();
+        public void Add(ICopyStrategy copyStrategy) => List.Add(copyStrategy);
+
+        public void ShallowCopy<T>() where T : Object => Add(new ShallowCopy<T>());
+        public void DeepCopy<T>(Func<Object, T> instantiate = null, Action<T, CustomCloneContext> duplicateFields = null, Action<T> postProcess = null)
+            where T : Object
+        {
+            Add(new DeepCopy<T>(instantiate, duplicateFields, postProcess));
+        }
+    }
+
+    
+    internal interface ICopyStrategy
+    {
+        bool Match(Object source);
+        Object GetCopy(Object source, CustomCloneContext context);
+    }
+
+    internal class ShallowCopy<T> : ICopyStrategy
+        where T : Object
+    {
+        public bool Match(Object source) => source is T;
+        public Object GetCopy(Object source, CustomCloneContext context) => source;
+    }
+    
+    internal class DeepCopy<T> : ICopyStrategy
+        where T : Object
+    {
+        readonly Func<Object, T> _instantiate;
+        readonly Action<T, CustomCloneContext> _duplicateFields;
+        readonly Action<T> _postProcess;
+
+        public DeepCopy(Func<Object, T> instantiate = null, Action<T, CustomCloneContext> duplicateFields = null, Action<T> postProcess = null)
+        {
+            _instantiate = instantiate ?? Instantiate;
+            _duplicateFields = duplicateFields ?? DuplicateFields;
+            _postProcess = postProcess ?? Postprocess;
+        }
+
+        public bool Match(Object source) => source is T;
+
+        public Object GetCopy(Object source, CustomCloneContext context)
+        {
+            if (context.Mapping.TryGetValue(source, out var mapped)) return mapped;
+            var target = _instantiate(source);
+            context.Mapping[source] = target;
+            _duplicateFields(target, context);
+            _postProcess(target);
+            return target;
+        }
+
+        protected virtual T Instantiate(Object source)
+        {
+            T target;
+            var ctor = typeof(T).GetConstructor(Type.EmptyTypes);
+            if (ctor == null || source is ScriptableObject)
+            {
+                target = (T) Object.Instantiate(source);
+                target.name = source.name;
+            }
+            else
+            {
+                target = (T) ctor.Invoke(Array.Empty<object>());
+                EditorUtility.CopySerialized(source, target);
+            }
+            return target;
+        }
+
+        protected virtual void DuplicateFields(T target, CustomCloneContext context)
+        {
+            var serializedObject = new SerializedObject(target);
+            var it = serializedObject.GetIterator();
+            
+            var enterChildren = true;
+            while (it.Next(enterChildren))
+            {
+                enterChildren = true;
+                switch (it.propertyType)
+                {
+                    case SerializedPropertyType.ObjectReference:
+                        it.objectReferenceValue = context.CachedClone(it.objectReferenceValue);
+                        break;
+                    // Iterating strings can get super slow...
+                    case SerializedPropertyType.String:
+                        enterChildren = false;
+                        break;
+                }
+            }
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        [UsedImplicitly]
+        protected virtual void Postprocess(T target)
+        {
+        }
+    }
+    
+    internal class CustomCloneException : Exception
+    {
+        public CustomCloneException(string message) : base(message) { }
+    }
+}
+
+#endif

--- a/Editor/VRM/CustomClone.cs.meta
+++ b/Editor/VRM/CustomClone.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8751b4155e9c4f7db0166928c35ee00e
+timeCreated: 1703890443

--- a/Editor/VRM/CustomCloneVRM10Object.cs
+++ b/Editor/VRM/CustomCloneVRM10Object.cs
@@ -6,7 +6,7 @@ using UniVRM10;
 
 namespace nadena.dev.modular_avatar.core.editor.vrm
 {
-    class CustomCloneVRM10Object : CustomClone<VRM10Object>
+    internal class CustomCloneVRM10Object : CustomClone<VRM10Object>
     {
         readonly bool _rename;
         readonly bool _copyThumbnail;

--- a/Editor/VRM/CustomCloneVRM10Object.cs
+++ b/Editor/VRM/CustomCloneVRM10Object.cs
@@ -1,0 +1,45 @@
+#if MA_VRM1
+
+using UnityEditor;
+using UnityEngine;
+using UniVRM10;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    class CustomCloneVRM10Object : CustomClone<VRM10Object>
+    {
+        readonly bool _rename;
+        readonly bool _copyThumbnail;
+
+        public CustomCloneVRM10Object(bool rename = false, bool copyThumbnail = false)
+        {
+            _rename = rename;
+            _copyThumbnail = copyThumbnail;
+        }
+        
+        protected override void Define(CopyStrategyDescriptor descriptor)
+        {
+            descriptor.DeepCopy<VRM10Object>(postProcess: Rename);
+            descriptor.DeepCopy<VRM10Expression>(postProcess: Rename);
+
+            if (_copyThumbnail)
+            {
+                descriptor.DeepCopy<Texture2D>();
+            }
+            else
+            {
+                descriptor.ShallowCopy<Texture2D>();
+            }
+            
+            descriptor.ShallowCopy<MonoScript>();
+            descriptor.ShallowCopy<GameObject>();
+
+            void Rename(Object obj)
+            {
+                if (_rename) obj.name = $"{obj.name} (Clone)";
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/VRM/CustomCloneVRM10Object.cs.meta
+++ b/Editor/VRM/CustomCloneVRM10Object.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f6ef11d926a947be9233781ee1287ad0
+timeCreated: 1703890449

--- a/Editor/VRM/MergeVRM0FirstPersonPass.cs
+++ b/Editor/VRM/MergeVRM0FirstPersonPass.cs
@@ -16,7 +16,7 @@ namespace nadena.dev.modular_avatar.core.editor.vrm
         }
     }
 
-    public class MergeVrm0FirstPersonProcessor
+    internal class MergeVrm0FirstPersonProcessor
     {
         public void ProcessVRM0(ndmf.BuildContext context)
         {

--- a/Editor/VRM/MergeVRM0FirstPersonPass.cs
+++ b/Editor/VRM/MergeVRM0FirstPersonPass.cs
@@ -1,0 +1,44 @@
+#if MA_VRM0
+
+using System.Linq;
+using nadena.dev.ndmf;
+using nadena.dev.modular_avatar.core.vrm;
+using VRM;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    internal class MergeVRM0FirstPersonPass : Pass<MergeVRM0FirstPersonPass>
+    {
+        protected override void Execute(ndmf.BuildContext context)
+        {
+            var processor = new MergeVrm0FirstPersonProcessor();
+            processor.ProcessVRM0(context);
+        }
+    }
+
+    public class MergeVrm0FirstPersonProcessor
+    {
+        public void ProcessVRM0(ndmf.BuildContext context)
+        {
+            var rootTransform = context.AvatarRootObject;
+            var vrmFirstPerson = rootTransform.GetComponent<VRMFirstPerson>();
+            if (!vrmFirstPerson) return;
+
+            var sources = rootTransform.GetComponentsInChildren<ModularAvatarMergeVRMFirstPerson>(); 
+
+            vrmFirstPerson.Renderers.AddRange(sources.SelectMany(source => source.renderers)
+                .Select(renderer => new VRMFirstPerson.RendererFirstPersonFlags
+                {
+                    Renderer = renderer.renderer,
+                    FirstPersonFlag = renderer.VRM0FirstPersonFlag
+                }));
+
+            foreach (var source in sources)
+            {
+                UnityEngine.Object.DestroyImmediate(source);
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/VRM/MergeVRM0FirstPersonPass.cs.meta
+++ b/Editor/VRM/MergeVRM0FirstPersonPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4269ba8a25504c01aa976586f94f15b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/VRM/MergeVRM1FirstPersonPass.cs
+++ b/Editor/VRM/MergeVRM1FirstPersonPass.cs
@@ -11,12 +11,12 @@ namespace nadena.dev.modular_avatar.core.editor.vrm
     {
         protected override void Execute(ndmf.BuildContext context)
         {
-            var processor = new MergeVrmFirstPersonProcessor();
+            var processor = new MergeVrm1FirstPersonProcessor();
             processor.ProcessVRM1(context);
         }
     }
 
-    public class MergeVrmFirstPersonProcessor
+    internal class MergeVrm1FirstPersonProcessor
     {
         public void ProcessVRM1(ndmf.BuildContext context)
         {

--- a/Editor/VRM/MergeVRM1FirstPersonPass.cs
+++ b/Editor/VRM/MergeVRM1FirstPersonPass.cs
@@ -1,0 +1,45 @@
+#if MA_VRM1
+
+using System.Linq;
+using nadena.dev.ndmf;
+using nadena.dev.modular_avatar.core.vrm;
+using UniVRM10;
+
+namespace nadena.dev.modular_avatar.core.editor.vrm
+{
+    internal class MergeVRM1FirstPersonPass : Pass<MergeVRM1FirstPersonPass>
+    {
+        protected override void Execute(ndmf.BuildContext context)
+        {
+            var processor = new MergeVrmFirstPersonProcessor();
+            processor.ProcessVRM1(context);
+        }
+    }
+
+    public class MergeVrmFirstPersonProcessor
+    {
+        public void ProcessVRM1(ndmf.BuildContext context)
+        {
+            var rootTransform = context.AvatarRootObject;
+            var vrmInstance = rootTransform.GetComponent<Vrm10Instance>();
+            if (!vrmInstance) return;
+
+            var sources = rootTransform.GetComponentsInChildren<ModularAvatarMergeVRMFirstPerson>();
+
+            vrmInstance.Vrm = new CustomCloneVRM10Object().Clone(vrmInstance.Vrm).mainAsset;
+            vrmInstance.Vrm.FirstPerson.Renderers.AddRange(sources.SelectMany(source => source.renderers)
+                .Select(renderer => new RendererFirstPersonFlags
+                {
+                    Renderer = RuntimeUtil.RelativePath(context.AvatarRootObject, renderer.renderer.gameObject),
+                    FirstPersonFlag = renderer.VRM1FirstPersonType
+                }));
+
+            foreach (var source in sources)
+            {
+                UnityEngine.Object.DestroyImmediate(source);
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/VRM/MergeVRM1FirstPersonPass.cs.meta
+++ b/Editor/VRM/MergeVRM1FirstPersonPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 972e2aec096f4e46afd5228b5509f2db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -6,7 +6,9 @@
         "VRC.SDK3A",
         "VRC.SDKBase",
         "nadena.dev.ndmf",
-        "nadena.dev.ndmf.vrchat"
+        "nadena.dev.ndmf.vrchat",
+        "VRM",
+        "VRM10"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -41,6 +41,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrmc.univrm",
+            "expression": "",
+            "define": "MA_VRM0"
+        },
+        {
+            "name": "com.vrmc.vrm",
+            "expression": "",
+            "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/VRM.meta
+++ b/Runtime/VRM.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e87fc31023354643907403ca7bb5c5fb
+timeCreated: 1697930873

--- a/Runtime/VRM/ModularAvatarMergeVRMFirstPerson.cs
+++ b/Runtime/VRM/ModularAvatarMergeVRMFirstPerson.cs
@@ -1,0 +1,74 @@
+#if MA_VRM0 || MA_VRM1
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+#if MA_VRM0
+using VRM;
+#endif
+
+#if MA_VRM1
+using UniGLTF.Extensions.VRMC_vrm;
+#endif
+
+namespace nadena.dev.modular_avatar.core.vrm
+{
+    [AddComponentMenu("Modular Avatar/MA Merge VRM0+1 FirstPerson")]
+    [DisallowMultipleComponent]
+    public class ModularAvatarMergeVRMFirstPerson : AvatarTagComponent
+    {
+        public List<RendererFirstPersonFlags> renderers = new List<RendererFirstPersonFlags>();
+        
+        [Serializable]
+        public struct RendererFirstPersonFlags
+        {
+            public Renderer renderer;
+            public ModularAvatarFirstPersonFlag firstPersonFlag;
+
+#if MA_VRM0
+            public FirstPersonFlag VRM0FirstPersonFlag
+            {
+                get
+                {
+                    switch (firstPersonFlag)
+                    {
+                        case ModularAvatarFirstPersonFlag.Auto: return FirstPersonFlag.Auto;
+                        case ModularAvatarFirstPersonFlag.Both: return FirstPersonFlag.Both;
+                        case ModularAvatarFirstPersonFlag.ThirdPersonOnly: return FirstPersonFlag.ThirdPersonOnly;
+                        case ModularAvatarFirstPersonFlag.FirstPersonOnly: return FirstPersonFlag.FirstPersonOnly;
+                        default: throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+#endif
+
+#if MA_VRM1
+            public FirstPersonType VRM1FirstPersonType
+            {
+                get
+                {
+                    switch (firstPersonFlag)
+                    {
+                        case ModularAvatarFirstPersonFlag.Auto: return FirstPersonType.auto;
+                        case ModularAvatarFirstPersonFlag.Both: return FirstPersonType.both;
+                        case ModularAvatarFirstPersonFlag.ThirdPersonOnly: return FirstPersonType.thirdPersonOnly;
+                        case ModularAvatarFirstPersonFlag.FirstPersonOnly: return FirstPersonType.firstPersonOnly;
+                        default: throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+#endif
+        }
+
+        public enum ModularAvatarFirstPersonFlag
+        {
+            Auto,
+            Both,
+            ThirdPersonOnly,
+            FirstPersonOnly,
+        }
+    }
+}
+
+#endif

--- a/Runtime/VRM/ModularAvatarMergeVRMFirstPerson.cs.meta
+++ b/Runtime/VRM/ModularAvatarMergeVRMFirstPerson.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1bc328746cf4d75bf0751ef4bfba97d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: a8edd5bd1a0a64a40aa99cc09fb5f198, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/nadena.dev.modular-avatar.core.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.core.asmdef
@@ -24,6 +24,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrmc.univrm",
+            "expression": "",
+            "define": "MA_VRM0"
+        },
+        {
+            "name": "com.vrmc.vrm",
+            "expression": "",
+            "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/nadena.dev.modular-avatar.core.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.core.asmdef
@@ -3,7 +3,9 @@
     "rootNamespace": "",
     "references": [
         "Unity.Burst",
-        "nadena.dev.ndmf.runtime"
+        "nadena.dev.ndmf.runtime",
+        "VRM",
+        "VRM10"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UnitTests~/Tests.asmdef
+++ b/UnitTests~/Tests.asmdef
@@ -30,6 +30,16 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+          "name": "com.vrmc.univrm",
+          "expression": "",
+          "define": "MA_VRM0"
+        },
+        {
+          "name": "com.vrmc.vrm",
+          "expression": "",
+          "define": "MA_VRM1"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Discussion: https://github.com/bdunderscore/modular-avatar/discussions/467
Merge base PR first: UniVRM components support #569 

![image](https://github.com/bdunderscore/modular-avatar/assets/4142423/520a065a-2237-4fdd-9c4f-b411917419ae)

This PR introduces `MA Merge VRM0+1 FirstPerson` component, which adds FirstPerson settings to `VRMFirstPerson` for VRM0 / `VRM10Object` for VRM1, respectively.
This component supports both VRM0 and VRM1 because the data structure is very similar.
This component does nothing when the target avatar is not VRM0 or VRM1.

I think there is nothing specific to this component that requires localization. Perhaps there could be some warning like "This component is ignored; supports VRM0 or VRM1 avatar only", but many other components that targets VRCSDK only have similar issue.

I have not yet added documents. Merging this PR reveals UniVRM support to end users, so documentation would block the next release once this PR is merged.
I don't know yet where to add documents. (It would be under `docs~/`, but I worry that throwing VRM specific components into the Component reference section makes little sense to VRC users, when the entire components list is even more growing).