### PR TITLE
fix: Rename Parameters should not impact sub-animator components

### DIFF
--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -296,26 +296,6 @@ namespace nadena.dev.modular_avatar.core.editor
                             break;
                         }
 
-                        case Animator anim:
-                        {
-                            if (willPurgeAnimators) break; // animator will be deleted in subsequent processing
-
-                            // RuntimeAnimatorController may be AnimatorOverrideController, convert in case of AnimatorOverrideController
-                            if (anim.runtimeAnimatorController is AnimatorOverrideController overrideController)
-                            {
-                                anim.runtimeAnimatorController = _context.ConvertAnimatorController(overrideController);
-                            }
-
-                            var controller = anim.runtimeAnimatorController as AnimatorController;
-                            if (controller != null)
-                            {
-                                ProcessAnimator(ref controller, remaps);
-                                anim.runtimeAnimatorController = controller;
-                            }
-
-                            break;
-                        }
-
                         case ModularAvatarMergeAnimator merger:
                         {
                             // RuntimeAnimatorController may be AnimatorOverrideController, convert in case of AnimatorOverrideController


### PR DESCRIPTION
Sub-animators have an independent parameter namespace from the main avatar, so we shouldn't
rename them.
