### PR TITLE
fix: issues with Scale Adjuster on 2019

### DIFF
--- a/Editor/HarmonyPatches/PatchLoader.cs
+++ b/Editor/HarmonyPatches/PatchLoader.cs
@@ -1,7 +1,9 @@
 ﻿#region
 
+using System;
 using HarmonyLib;
 using UnityEditor;
+using UnityEngine;
 
 #endregion
 
@@ -9,13 +11,29 @@ namespace nadena.dev.modular_avatar.core.editor.HarmonyPatches
 {
     internal class PatchLoader
     {
+        private static readonly Action<Harmony>[] patches = new Action<Harmony>[]
+        {
+            SnoopHeaderRendering.Patch1,
+            SnoopHeaderRendering.Patch2,
+            HideScaleAdjusterFromPrefabOverrideView.Patch
+        };
+
         [InitializeOnLoadMethod]
         static void ApplyPatches()
         {
             var harmony = new Harmony("nadena.dev.modular_avatar");
 
-            SnoopHeaderRendering.Patch(harmony);
-            HideScaleAdjusterFromPrefabOverrideView.Patch(harmony);
+            foreach (var patch in patches)
+            {
+                try
+                {
+                    patch(harmony);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+            }
         }
     }
 }

--- a/Editor/HarmonyPatches/SnoopHeaderRendering.cs
+++ b/Editor/HarmonyPatches/SnoopHeaderRendering.cs
@@ -16,7 +16,7 @@ namespace nadena.dev.modular_avatar.core.editor.HarmonyPatches
     /// </summary>
     internal class SnoopHeaderRendering
     {
-        internal static void Patch(Harmony harmony)
+        internal static void Patch1(Harmony harmony)
         {
             var t_orig = AccessTools.TypeByName("UnityEditor.UIElements.EditorElement");
             var m_orig = AccessTools.Method(t_orig, "HeaderOnGUI");
@@ -24,9 +24,14 @@ namespace nadena.dev.modular_avatar.core.editor.HarmonyPatches
             var m_prefix = AccessTools.Method(typeof(SnoopHeaderRendering), "Prefix");
 
             harmony.Patch(original: m_orig, prefix: new HarmonyMethod(m_prefix));
+        }
 
+        internal static void Patch2(Harmony harmony)
+        {
             var t_GUIUtility = typeof(GUIUtility);
             var m_ProcessEvent = AccessTools.Method(t_GUIUtility, "ProcessEvent");
+
+            var m_prefix = AccessTools.Method(typeof(SnoopHeaderRendering), "Prefix");
 
             harmony.Patch(original: m_ProcessEvent, prefix: new HarmonyMethod(m_prefix));
         }

--- a/Editor/HarmonyPatches/nadena.dev.modular-avatar.harmony-patches.asmdef
+++ b/Editor/HarmonyPatches/nadena.dev.modular-avatar.harmony-patches.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "nadena.dev.modular-avatar.harmony-patches",
-    "rootNamespace": "",
     "references": [
         "nadena.dev.modular-avatar.core",
         "nadena.dev.modular-avatar.core.editor",
@@ -20,7 +19,7 @@
     "versionDefines": [
         {
             "name": "com.vrchat.base",
-            "expression": "(3.4.999,)",
+            "expression": "(3.3.99999,)",
             "define": "VRCSDK_HAS_HARMONY"
         }
     ],

--- a/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
+++ b/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
@@ -18,13 +18,15 @@ namespace nadena.dev.modular_avatar.core
         private static event Action OnClearAllOverrides;
         private static int RecreateHierarchyIndexCount = 0;
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         [UnityEditor.InitializeOnLoadMethod]
         static void Setup()
         {
             UnityEditor.EditorApplication.hierarchyChanged += InvalidateAll;
+            UnityEditor.AssemblyReloadEvents.beforeAssemblyReload += ClearAllOverrides;
+            UnityEditor.SceneManagement.EditorSceneManager.sceneSaving += (scene, path) => ClearAllOverrides();
         }
-        #endif
+#endif
 
         internal static void InvalidateAll()
         {
@@ -40,7 +42,7 @@ namespace nadena.dev.modular_avatar.core
 
         internal Dictionary<Transform, Transform> BoneMappings = new Dictionary<Transform, Transform>();
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         private void OnValidate()
         {
             if (UnityEditor.PrefabUtility.IsPartOfPrefabAsset(this)) return;
@@ -61,8 +63,8 @@ namespace nadena.dev.modular_avatar.core
                 }
             };
         }
-        #endif
-        
+#endif
+
         private Transform MapBone(Transform bone)
         {
             if (bone == null) return null;
@@ -75,7 +77,7 @@ namespace nadena.dev.modular_avatar.core
             ClearAllOverrides();
         }
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         private void Update()
         {
             if (myRenderer == null)
@@ -152,7 +154,7 @@ namespace nadena.dev.modular_avatar.core
             // re-disabled; re-enabler it in delayCall in this case.
             UnityEditor.EditorApplication.delayCall += ClearLocalOverride;
         }
-        #endif
+#endif
 
         private void ClearLocalOverride()
         {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "com.unity.nuget.newtonsoft-json": "2.0.0"
   },
   "vpmDependencies": {
-    "com.vrchat.avatars": ">=3.2.0",
+    "com.vrchat.avatars": ">=3.4.0",
     "nadena.dev.ndmf": ">=1.3.1 <2.0.0-a"
   }
 }


### PR DESCRIPTION
Harmony patches were not being loaded for VRCSDK 3.4.x, causing some issues with component enabled state checkboxes being incorrect.

Additionally, we need to reset component states before assembly reload and scene save.
