### PR TITLE
fix: ScaleAdjuster causes console errors when a mesh is missing

### DIFF
--- a/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
+++ b/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
@@ -120,11 +120,14 @@ namespace nadena.dev.modular_avatar.core
             myRenderer.motionVectorGenerationMode = parentRenderer.motionVectorGenerationMode;
             myRenderer.allowOcclusionWhenDynamic = parentRenderer.allowOcclusionWhenDynamic;
 
-            var blendShapeCount = myRenderer.sharedMesh.blendShapeCount;
-
-            for (int i = 0; i < blendShapeCount; i++)
+            if (myRenderer.sharedMesh != null)
             {
-                myRenderer.SetBlendShapeWeight(i, parentRenderer.GetBlendShapeWeight(i));
+                var blendShapeCount = myRenderer.sharedMesh.blendShapeCount;
+
+                for (int i = 0; i < blendShapeCount; i++)
+                {
+                    myRenderer.SetBlendShapeWeight(i, parentRenderer.GetBlendShapeWeight(i));
+                }
             }
 
             ClearAllOverrides();

--- a/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
+++ b/Runtime/ScaleAdjuster/ScaleAdjusterRenderer.cs
@@ -11,7 +11,7 @@ using VRC.SDKBase;
 namespace nadena.dev.modular_avatar.core
 {
     [ExecuteInEditMode]
-    //[AddComponentMenu("")]
+    [AddComponentMenu("")]
     [RequireComponent(typeof(SkinnedMeshRenderer))]
     internal class ScaleAdjusterRenderer : MonoBehaviour, IEditorOnly
     {


### PR DESCRIPTION
- fix: ScaleAdjuster causes console errors when a mesh is missing
- chore: hide ScaleAdjusterRenderer component
