### PR TITLE
chore: Fix non-VRChat support

### DIFF
--- a/Editor/ApplyAnimatorDefaultValuesPass.cs
+++ b/Editor/ApplyAnimatorDefaultValuesPass.cs
@@ -15,6 +15,8 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             var values = context.GetState<DefaultValues>()?.InitialValueOverrides
                          ?? ImmutableDictionary<string, float>.Empty;
 


### PR DESCRIPTION
Fixed some compile errors I've found when using Modular Avatar in VRCSDK project with non-VRChat avatars, but for MA 1.9.4.

Note: Actually we don't need this PR until bdunderscore/ndmf#71 is merged, because AvatarRoot without VRCAvatarDescriptor in VRCSDK projects would not be allowed until then.