### PR TITLE
MA MoveIndependently をMAの処理終了時にパージする

### DIFF
--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -84,6 +84,10 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                     {
                         UnityEngine.Object.DestroyImmediate(component);
                     }
+                    foreach (var component in ctx.AvatarRootTransform.GetComponentsInChildren<ArmatureAwase.MAMoveIndependently>(true))
+                    {
+                        UnityEngine.Object.DestroyImmediate(component);
+                    }
                 });
 #if MA_VRCSDK3_AVATARS
                 seq.Run(PruneParametersPass.Instance);


### PR DESCRIPTION
AAO に警告出されること以外影響はなく、シーンをリロードでもすればこの問題は発生しませんが、あったほうが良いと私は思います。

とりあえずで MAMoveIndependently だけを指定して削除していますが、編集ツールのようなコンポーネントが今後増えるならインターフェース指定で削除する実装にしてもいいかもしれないですね！