### PR TITLE
Fix For Audio Clip References in Animator

### DIFF
--- a/Editor/Animation/DeepClone.cs
+++ b/Editor/Animation/DeepClone.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using nadena.dev.modular_avatar.core.editor;
 using nadena.dev.ndmf;
@@ -50,7 +50,8 @@ namespace nadena.dev.modular_avatar.animation
                 case AnimatorTransitionBase _:
                 case StateMachineBehaviour _:
                     break; // We want to clone these types
-
+                    
+                case AudioClip _: //Used in VRC Animator Play Audio State Behavior
                 // Leave textures, materials, and script definitions alone
                 case Texture2D _:
                 case MonoScript _:


### PR DESCRIPTION
Quick fix for the new [Animator Play Audio State Behavior](https://vrc-beta-docs.netlify.app/avatars/state-behaviors#animator-play-audio) available in SDK 3.5.2 Open Beta.