### PR TITLE
fix: FreeSegment "segment not found" errors

### DIFF
--- a/UnitTests~/ArmatureAwase/AllocationMapTest.cs
+++ b/UnitTests~/ArmatureAwase/AllocationMapTest.cs
@@ -91,7 +91,7 @@ namespace UnitTests.ArmatureAwase
                         {
                             case 0:
                             {
-                                int segSize = r.Next(1, 16);
+                                int segSize = r.Next(0, 16);
                                 ISegment s = map.Allocate(segSize);
                                 ops.Add((Op.Allocate, segSize));
                                 segments.Add(s);


### PR DESCRIPTION
Zero-length allocations could result in multiple entries with the same offset in the segment map. This would then break subsequent lookups.

Fixed by increasing these allocations to a minimum length of one.
