### PR TITLE
MA Information の表示される GameObject を制限する

### DIFF
--- a/Editor/HarmonyPatches/InjectParamsUsageUI.cs
+++ b/Editor/HarmonyPatches/InjectParamsUsageUI.cs
@@ -92,11 +92,16 @@ namespace nadena.dev.modular_avatar.core.editor.HarmonyPatches
 
             if (editor.targets.Length != 1) return;
 
-            if (editor.target is GameObject obj)
-            {
-                var elem = new ParamsUsageUI();
-                container.Add(elem);
-            }
+            if (editor.target is not GameObject obj) return;
+
+            Component defComponent = obj.GetComponent<AvatarTagComponent>();
+#if MA_VRCSDK3_AVATARS
+            if (defComponent == null) defComponent = obj.GetComponent<VRC.SDK3.Avatars.Components.VRCAvatarDescriptor>();
+#endif
+            if (defComponent == null) return;
+
+            var elem = new ParamsUsageUI();
+            container.Add(elem);
         }
     }
 }


### PR DESCRIPTION
パラメーターを多く使わないユーザーにとっては、 MA Information は大した価値がありません。
なので、すべての場所に表示されるのは正直邪魔ですが、必要のある場所に表示されるのことは良いと思っています。

このプルリクエストでは、 MAの AvatarTagComponent を継承したコンポーネントか AvatarDescriptor が存在する GameObject にのみ制限してみました。
できるなら パラメーター情報を提供するコンポーネントもそれに含めることができたら、とてもいいですね！

ただ、どこまで制限するかはオプションにするのがいいと私は思います。

例えば
- すべての GameObject に
- パラメーターに関与するコンポーネントが存在する GameObject に
- 一切表示しない related #815

の三つがあると良いですが、オプションにするかどうかの判断は私にはできないのでこのプルリクエストでは実装されていません。