### PR TITLE
fix: disable parameter cost check for now

### DIFF
--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -260,7 +260,8 @@ namespace nadena.dev.modular_avatar.core.editor
             }
 
             expParams.parameters = parameters.ToArray();
-     
+
+            /*
             if (expParams.CalcTotalCost() > VRCExpressionParameters.MAX_PARAMETER_COST)
             {
                 BuildReport.LogFatal("error.rename_params.too_many_synced_params", new[]
@@ -270,6 +271,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     }
                 );
             }
+            */
 
             avatar.expressionParameters = expParams;
         }


### PR DESCRIPTION
This creates compatibility issues with VRCF, as well as being
run in the wrong phase of processing in any case.

At some point this will need to be restored, as part of a new
NDMF processing phase that runs much later in the build.

Fixes: #813, #806
