### PR TITLE
Fix mobile display of document top page

### DIFF
--- a/docs~/src/pages/index.module.css
+++ b/docs~/src/pages/index.module.css
@@ -17,14 +17,18 @@
 }
 
 .buttons {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
   justify-content: center;
+  column-gap: 2rem;
+  row-gap: 1rem;
 }
 
-.button {
-    margin-right: 1rem;
-    margin-left: 1rem;
+@media screen and (max-width: 996px) {
+  .buttons {
+    grid-auto-flow: row;
+  }
 }
 
 div.logo {


### PR DESCRIPTION
## Overview

Fixed an issue where button placement was disrupted when the document width is small. 

| before | after |
| --- | --- |
| ![image](https://github.com/bdunderscore/modular-avatar/assets/60507815/ff5cf34d-97f4-418f-935c-c10be16991ad) | ![image](https://github.com/bdunderscore/modular-avatar/assets/60507815/0988785c-741d-4165-af7f-6cf699425fe7) |

(images are not displayed due to preview issue)

## Details

Buttons now align vertically when document is switched to single column layout. Use grid instead of flexbox to match the width of each button when vertically aligned.