### PR TITLE
Implement VRCAnimatorPlayAudio handling logic

### DIFF
--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -80,37 +80,12 @@ namespace nadena.dev.modular_avatar.animation
             }
         }
 
-#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-        internal class PlayAudioHolder
-        {
-            private VRCAnimatorPlayAudio _currentPlayAudio;
-
-            internal VRCAnimatorPlayAudio CurrentPlayAudio
-            {
-                get
-                {
-                    return _currentPlayAudio;
-                }
-                set
-                {
-                    _currentPlayAudio = value;
-                }
-            }
-
-            internal PlayAudioHolder(VRCAnimatorPlayAudio audio)
-            {
-                CurrentPlayAudio = audio;
-            }
-        }
-#endif
-
-
         private BuildContext _context;
 
         private List<Action> _clipCommitActions = new List<Action>();
         private List<ClipHolder> _clips = new List<ClipHolder>();
 #if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-        private List<PlayAudioHolder> _playAudios = new List<PlayAudioHolder>();
+        private HashSet<VRCAnimatorPlayAudio> _playAudios = new HashSet<VRCAnimatorPlayAudio>();
 #endif
 
         private Dictionary<string, HashSet<ClipHolder>> _pathToClip = null;
@@ -203,13 +178,11 @@ namespace nadena.dev.modular_avatar.animation
             if (processClip == null) processClip = (_) => { };
 
 #if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-            Dictionary<VRCAnimatorPlayAudio, PlayAudioHolder> _originalToAudioHolder = new Dictionary<VRCAnimatorPlayAudio, PlayAudioHolder>();
-
             foreach (var behavior in state.behaviours)
             {
                 if (behavior is VRCAnimatorPlayAudio playAudio)
                 {
-                    var audioHolder = RegisterPlayAudio(playAudio, _originalToAudioHolder);
+                    _playAudios.Add(playAudio);
                 }
             }
 #endif
@@ -231,7 +204,7 @@ namespace nadena.dev.modular_avatar.animation
         }
 
 #if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-        internal void ForeachPlayAudio(Action<PlayAudioHolder> processPlayAudio)
+        internal void ForeachPlayAudio(Action<VRCAnimatorPlayAudio> processPlayAudio)
         {
             foreach (var playAudioHolder in _playAudios)
             {
@@ -313,30 +286,6 @@ namespace nadena.dev.modular_avatar.animation
             originalToHolder[motion] = holder;
             return holder;
         }
-
-#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-        private PlayAudioHolder RegisterPlayAudio(
-            VRCAnimatorPlayAudio playAudio,
-            Dictionary<VRCAnimatorPlayAudio, PlayAudioHolder> originalToHolder
-        )
-        {
-            if (playAudio == null)
-            {
-                return new PlayAudioHolder(null);
-            }
-
-            if (originalToHolder.TryGetValue(playAudio, out var holder))
-            {
-                return holder;
-            }
-
-            holder = new PlayAudioHolder(playAudio);
-            _playAudios.Add(holder);
-
-            originalToHolder[playAudio] = holder;
-            return holder;
-        }
-#endif
 
         private void InvalidateCaches()
         {

--- a/Editor/Animation/AnimatorCombiner.cs
+++ b/Editor/Animation/AnimatorCombiner.cs
@@ -496,7 +496,7 @@ namespace nadena.dev.modular_avatar.animation
                         for (int i = 0; i < overrideBehaviors.Length; i++)
                         {
                             overrideBehaviors[i] = _deepClone.DoClone(overrideBehaviors[i]);
-                            AdjustBehavior(overrideBehaviors[i]);
+                            AdjustBehavior(overrideBehaviors[i], basePath);
                         }
 
                         newLayer.SetOverrideBehaviours((AnimatorState)_cloneMap[state], overrideBehaviors);
@@ -578,7 +578,7 @@ namespace nadena.dev.modular_avatar.animation
             {
                 foreach (var behavior in state.behaviours)
                 {
-                    AdjustBehavior(behavior);
+                    AdjustBehavior(behavior, basePath);
                 }
             }
 
@@ -586,7 +586,7 @@ namespace nadena.dev.modular_avatar.animation
             return asm;
         }
 
-        private void AdjustBehavior(StateMachineBehaviour behavior)
+        private void AdjustBehavior(StateMachineBehaviour behavior, string basePath)
         {
 #if MA_VRCSDK3_AVATARS
             switch (behavior)
@@ -598,6 +598,16 @@ namespace nadena.dev.modular_avatar.animation
                     layerControl.layer += _controllerBaseLayer;
                     break;
                 }
+#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
+                case VRCAnimatorPlayAudio playAudio:
+                {
+                    if (!string.IsNullOrEmpty(playAudio.SourcePath) && !string.IsNullOrEmpty(basePath) && !playAudio.SourcePath.StartsWith(basePath))
+                    {
+                        playAudio.SourcePath = $"{basePath}/{playAudio.SourcePath}";
+                    }
+                    break;
+                }
+#endif
             }
 #endif
         }

--- a/Editor/Animation/PathMappings.cs
+++ b/Editor/Animation/PathMappings.cs
@@ -167,7 +167,6 @@ namespace nadena.dev.modular_avatar.animation
                     if (!dict.ContainsKey(origPath))
                     {
                         dict = dict.Add(origPath, newPath);
-                        Debug.Log($"Mapping {origPath} -> {newPath}");
                     }
                 }
             }
@@ -281,9 +280,7 @@ namespace nadena.dev.modular_avatar.animation
 #if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
         private VRCAnimatorPlayAudio ApplyMappingsToPlayAudio(VRCAnimatorPlayAudio audio)
         {
-            Debug.Log($"SourcePath: {audio.SourcePath}");
             audio.SourcePath = MapPath(audio.SourcePath, true);
-            Debug.Log($"DestPath: {audio.SourcePath}");
             return audio;
         }
 #endif
@@ -301,12 +298,9 @@ namespace nadena.dev.modular_avatar.animation
             });
 
 #if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
-            _animationDatabase.ForeachPlayAudio(holder =>
+            _animationDatabase.ForeachPlayAudio(playAudio =>
             {
-                if (holder.CurrentPlayAudio is VRCAnimatorPlayAudio playAudio)
-                {
-                    holder.CurrentPlayAudio = ApplyMappingsToPlayAudio(playAudio);
-                }
+                ApplyMappingsToPlayAudio(playAudio);
             });
 #endif
 

--- a/Editor/Animation/PathMappings.cs
+++ b/Editor/Animation/PathMappings.cs
@@ -8,6 +8,9 @@ using nadena.dev.ndmf.util;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
+#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
+using VRC.SDK3.Avatars.Components;
+#endif
 
 #endregion
 
@@ -164,6 +167,7 @@ namespace nadena.dev.modular_avatar.animation
                     if (!dict.ContainsKey(origPath))
                     {
                         dict = dict.Add(origPath, newPath);
+                        Debug.Log($"Mapping {origPath} -> {newPath}");
                     }
                 }
             }
@@ -274,6 +278,16 @@ namespace nadena.dev.modular_avatar.animation
             return newClip;
         }
 
+#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
+        private VRCAnimatorPlayAudio ApplyMappingsToPlayAudio(VRCAnimatorPlayAudio audio)
+        {
+            Debug.Log($"SourcePath: {audio.SourcePath}");
+            audio.SourcePath = MapPath(audio.SourcePath, true);
+            Debug.Log($"DestPath: {audio.SourcePath}");
+            return audio;
+        }
+#endif
+
         internal void OnDeactivate(BuildContext context)
         {
             Dictionary<AnimationClip, AnimationClip> clipCache = new Dictionary<AnimationClip, AnimationClip>();
@@ -285,6 +299,16 @@ namespace nadena.dev.modular_avatar.animation
                     holder.CurrentClip = ApplyMappingsToClip(clip, clipCache);
                 }
             });
+
+#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
+            _animationDatabase.ForeachPlayAudio(holder =>
+            {
+                if (holder.CurrentPlayAudio is VRCAnimatorPlayAudio playAudio)
+                {
+                    holder.CurrentPlayAudio = ApplyMappingsToPlayAudio(playAudio);
+                }
+            });
+#endif
 
             foreach (var listener in context.AvatarRootObject.GetComponentsInChildren<IOnCommitObjectRenames>())
             {

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -43,6 +43,11 @@
             "name": "com.vrchat.avatars",
             "expression": "",
             "define": "MA_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.5.2",
+            "define": "MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
This is my attempt to implement handling source path inside `VRCAnimatorPlayAudio` for Modular Avatar. (#783, #858)
It is a quite dirty approach and don't know if the code quality is qualifiable to merge into upstream so I file a PR here anyways.

Before Animator Merging:
![image](https://github.com/bdunderscore/modular-avatar/assets/4715281/c44e583a-8cf9-4253-bb11-024fa3edcfb2)

After Animator Merging:
![image](https://github.com/bdunderscore/modular-avatar/assets/4715281/3475d476-1581-4839-bb5e-c761a2039441)
