### PR TITLE
ci: add zipSHA256 support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,12 +64,14 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip >> $GITHUB_ENV
+          echo "zipFileSHA256=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip.sha256 >> $GITHUB_ENV
           echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.prop }}.unitypackage" >> $GITHUB_ENV
 
       - name: Create Zip
         run: |
           zip ".github/${{env.zipFile}}" ./* -r -x .github .git '.git/*' '*~/*' '*.ps1*'
           mv ".github/${{env.zipFile}}" "${{env.zipFile}}"
+          sha256sum "${{env.zipFile}}" > "${{env.zipFileSHA256}}"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -85,4 +87,5 @@ jobs:
           tag_name: ${{ steps.version.outputs.prop }}
           files: |
             ${{ env.zipFile }}
+            ${{ env.zipFileSHA256 }}
             package.json


### PR DESCRIPTION
With bdunderscore/vpm-repo-list-generator#318, zipSHA256 support will be added