### PR TITLE
fix: Scale Adjuster breaks physbones

### DIFF
--- a/Editor/ScaleAdjusterPass.cs
+++ b/Editor/ScaleAdjusterPass.cs
@@ -18,6 +18,7 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 var proxyObject = new GameObject("ScaleProxy");
                 var proxyTransform = proxyObject.transform;
+                proxyObject.AddComponent<ModularAvatarPBBlocker>();
 
                 proxyTransform.SetParent(adjuster.transform, false);
                 proxyTransform.localPosition = Vector3.zero;


### PR DESCRIPTION
Scale Adjuster introduces child transforms, and thus needs to add PB exclusions
to avoid breaking parent PB chains.

Closes: #924
