### PR TITLE
fix: cursed interaction with Unity Timeline causes animation curves to be lost

### DIFF
--- a/Editor/Animation/PathMappings.cs
+++ b/Editor/Animation/PathMappings.cs
@@ -196,7 +196,7 @@ namespace nadena.dev.modular_avatar.animation
             }
         }
 
-        private string MapPath(UnityEditor.EditorCurveBinding binding)
+        private string MapPath(EditorCurveBinding binding)
         {
             if (binding.type == typeof(Animator) && binding.path == "")
             {
@@ -249,7 +249,10 @@ namespace nadena.dev.modular_avatar.animation
             {
                 var newBinding = binding;
                 newBinding.path = MapPath(binding);
-                newClip.SetCurve(newBinding.path, newBinding.type, newBinding.propertyName,
+                // https://github.com/bdunderscore/modular-avatar/issues/950
+                // It's reported that sometimes using SetObjectReferenceCurve right after SetCurve might cause the
+                // curves to be forgotten; use SetEditorCurve instead.
+                AnimationUtility.SetEditorCurve(newClip, newBinding,
                     AnimationUtility.GetEditorCurve(originalClip, binding));
             }
 


### PR DESCRIPTION
Closes: #950
