### PR TITLE
chore: Fix non-VRChat support

### DIFF
--- a/Editor/ReactiveObjects/ParameterAssignerPass.cs
+++ b/Editor/ReactiveObjects/ParameterAssignerPass.cs
@@ -43,6 +43,8 @@ namespace nadena.dev.modular_avatar.core.editor
         
         protected override void Execute(ndmf.BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+            
             var paramIndex = 0;
 
             var declaredParams = context.AvatarDescriptor.expressionParameters.parameters.Select(p => p.name)


### PR DESCRIPTION
Added hack to fix runtime errors I've found when using Modular Avatar in VRCSDK project with non-VRChat avatars like #650 #731, but for MA 1.10.0-rc1.

