### PR TITLE
fix: parent parameters can override child menu item default value

### DIFF
--- a/Editor/ParamsUsage/MAParametersIntrospection.cs
+++ b/Editor/ParamsUsage/MAParametersIntrospection.cs
@@ -88,7 +88,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     IsAnimatorOnly = animatorOnly,
                     WantSynced = !p.localOnly,
                     IsHidden = p.internalParameter,
-                    DefaultValue = p.defaultValue
+                    DefaultValue = p.HasDefaultValue ? p.defaultValue : null
                 };
             });
         }

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
@@ -62,7 +62,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
                     _computeContext.Observe(mami, c => (c.Control?.parameter, c.Control?.type, c.Control?.value, c.isDefault));
                     
-                    var mami_condition = ParameterAssignerPass.AssignMenuItemParameter(mami, _simulationInitialStates);
+                    var mami_condition = ParameterAssignerPass.AssignMenuItemParameter(mami, _simulationInitialStates, context: _computeContext);
 
                     if (mami_condition != null &&
                         ForceMenuItems.TryGetValue(mami_condition.Parameter, out var forcedMenuItem))

--- a/Editor/ReactiveObjects/MenuItemPreviewCondition.cs
+++ b/Editor/ReactiveObjects/MenuItemPreviewCondition.cs
@@ -61,7 +61,9 @@ namespace nadena.dev.modular_avatar.core.editor
 
             var (paramName, value) = _context.Observe(mami, m => (m.Control.parameter.name, m.Control.value));
 
-            if (TryGetRegisteredParam(mami, paramName, out var providedParameter))
+            if (!_context.Observe(mami, m => m.automaticValue)
+                && TryGetRegisteredParam(mami, paramName, out var providedParameter)
+                && providedParameter.DefaultValue != null)
             {
                 var defaultValue = providedParameter.DefaultValue ?? 0;
                 return Mathf.Abs(defaultValue - value) < 0.01f;

--- a/Editor/ReactiveObjects/ParameterAssignerPass.cs
+++ b/Editor/ReactiveObjects/ParameterAssignerPass.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.ndmf;
+using nadena.dev.ndmf.preview;
 using UnityEngine;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -177,6 +178,7 @@ namespace nadena.dev.modular_avatar.core.editor
             ModularAvatarMenuItem mami,
             Dictionary<string, float> simulationInitialStates = null,
             IDictionary<string, ModularAvatarMenuItem> isDefaultOverrides = null,
+            ComputeContext context = null,
             bool? forceSimulation = null
             )
         {
@@ -207,6 +209,10 @@ namespace nadena.dev.modular_avatar.core.editor
             
             if (string.IsNullOrWhiteSpace(paramName)) return null;
             
+            var isEnabledForPreview = context != null
+                ? new MenuItemPreviewCondition(context).IsEnabledForPreview(mami)
+                : mami.isDefault;
+
             return new ControlCondition
             {
                 Parameter = paramName,
@@ -215,7 +221,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 // Note: This slightly odd-looking value is key to making the Auto checkbox work for editor previews;
                 // we basically force-disable any conditions for nonselected menu items and force-enable any for default
                 // menu items.
-                InitialValue = mami.isDefault ? mami.Control.value : -999,
+                InitialValue = isEnabledForPreview ? mami.Control.value : -999,
                 ParameterValueLo = mami.Control.value - 0.005f,
                 ParameterValueHi = mami.Control.value + 0.005f,
                 DebugReference = mami,

--- a/Runtime/ModularAvatarMenuItem.cs
+++ b/Runtime/ModularAvatarMenuItem.cs
@@ -181,6 +181,15 @@ namespace nadena.dev.modular_avatar.core
                 VRCExpressionParameters.ValueType.Float => AnimatorControllerParameterType.Float,
                 _ => 0,
             };
+
+        internal ParameterSyncType ParameterSyncType
+            => ExpressionParametersValueType switch
+            {
+                VRCExpressionParameters.ValueType.Bool => ParameterSyncType.Bool,
+                VRCExpressionParameters.ValueType.Int => ParameterSyncType.Int,
+                VRCExpressionParameters.ValueType.Float => ParameterSyncType.Float,
+                _ => 0,
+            };
     }
 }
 


### PR DESCRIPTION
#1158 の対応ですが、どうすればよいか分からない問題が残っているので Draft のままです。
bd_ さんが対応された方が確実 & 早そうなので Close でも大丈夫です。

- プレビューのみの処理ではないところで MenuItemPreviewCondition を使っている
(そもそもどこでも使われていなかった MenuItemPreviewCondition は使って大丈夫なものなのか)
- 親の MA Parameters の初期値が未指定な場合は子の MA Menu Item の「初期設定にする」を変更できるようにしたいが、ParameterInfo に Source とは別にデフォルト値の提供元がないので判別できない
- ndmf を [eef1d86](https://github.com/bdunderscore/ndmf/commit/eef1d864d0c925c2d72e4d34868c90e2df6a697c) 以降にすると親の MA Parameters の初期値を変更してもプレビューが更新されなくなってしまった
([7d26771](https://github.com/bdunderscore/ndmf/commit/7d26771a064aca1962ebca95e9648f0239e5339e) までなら更新される)