### PR TITLE
fix: animation clips are not added to the persistent asset object on build

### DIFF
--- a/Editor/Animation/DeepClone.cs
+++ b/Editor/Animation/DeepClone.cs
@@ -93,6 +93,11 @@ namespace nadena.dev.modular_avatar.animation
                 {
                     ObjectRegistry.RegisterReplacedObject(original, obj);
                 }
+                
+                if (_isSaved && !EditorUtility.IsPersistent(obj))
+                {
+                    AssetDatabase.AddObjectToAsset(obj, _combined);
+                }
 
                 return (T)obj;
             }


### PR DESCRIPTION
This resulted in data loss when `AssetDatabase.StopAssetEditing()` was called, which can happen if VRCF triggers Poi lockdown.
