### PR TITLE
Visible Head Accessoryがhead以下にない時の表示をエラーから警告に変更

### DIFF
--- a/Editor/Inspector/FirstPersonVisibleEditor.cs
+++ b/Editor/Inspector/FirstPersonVisibleEditor.cs
@@ -35,6 +35,9 @@ namespace nadena.dev.modular_avatar.core.editor
                     case VisibleHeadAccessoryValidation.ReadyStatus.ParentMarked:
                         EditorGUILayout.HelpBox(Localization.S("fpvisible.normal"), MessageType.Info);
                         break;
+                    case VisibleHeadAccessoryValidation.ReadyStatus.NotUnderHead:
+                        EditorGUILayout.HelpBox(Localization.S("fpvisible.NotUnderHead"), MessageType.Warning);
+                        break;
                     default:
                     {
                         var label = "fpvisible." + status;


### PR DESCRIPTION
improve: #599 
issueをcloseするかどうかはお任せします。

https://github.com/bdunderscore/modular-avatar/issues/599#issuecomment-2367449759 により、文言修正は今のところ行っていません。
BoneProxyの検知ですが、自身についていたら良いのですが、自身の親やその親がBoneProxyでHead以下に移動する場合などが想定されると思うので、(毎回親まで辿ることになるのは)負荷が高そうだな…と思って手を付けませんでした。