### PR TITLE
fix: Setup Outfit cause NRE when nothing selected

### DIFF
--- a/Editor/SetupOutfit.cs
+++ b/Editor/SetupOutfit.cs
@@ -386,6 +386,14 @@ namespace nadena.dev.modular_avatar.core.editor
         private static bool ValidateSetupOutfit(GameObject gameObj)
         {
             Object obj;
+
+            if (gameObj == null)
+            {
+                errorHeader = S("setup_outfit.err.header.notarget");
+                errorMessageGroups = new string[] { S("setup_outfit.err.no_selection") };
+                return false;
+            }
+
             errorHeader = S_f("setup_outfit.err.header", gameObj.name);
             var xform = gameObj.transform;
 


### PR DESCRIPTION
fix: #1196 
(ちなみに、変更点の真上の行に使用されていない"obj"変数の宣言があるようですが、消し忘れでしょうか…?)

(a bit related to #1195 ?)