### PR TITLE
feat: replace checkboxes in ObjectToggle with dropdowns

### DIFF
--- a/Editor/Inspector/ObjectToggle/ObjectSwitcherStyles.uss
+++ b/Editor/Inspector/ObjectToggle/ObjectSwitcherStyles.uss
@@ -39,12 +39,16 @@
     margin: 0;
 }
 
-#f-active {
-    justify-content: center;
-}
-
 #f-object {
     flex-grow: 1;
+}
+
+#f-active {
+    display: none;
+}
+
+#f-active-dropdown {
+    width: 60px;
 }
 
 .drop-area--drag-active > ListView ScrollView {

--- a/Editor/Inspector/ObjectToggle/ToggledObjectEditor.cs
+++ b/Editor/Inspector/ObjectToggle/ToggledObjectEditor.cs
@@ -15,6 +15,9 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
         private const string UxmlPath = Root + "ToggledObjectEditor.uxml";
         private const string UssPath = Root + "ObjectSwitcherStyles.uss";
 
+        private const string V_On = "ON";
+        private const string V_Off = "OFF";
+
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
             var uxml = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UxmlPath).CloneTree();
@@ -23,6 +26,21 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
             Localization.UI.Localize(uxml);
             uxml.styleSheets.Add(uss);
             uxml.BindProperty(property);
+
+            var f_active = uxml.Q<Toggle>("f-active");
+            var f_active_dropdown = uxml.Q<DropdownField>("f-active-dropdown");
+
+            f_active_dropdown.choices.Add(V_On);
+            f_active_dropdown.choices.Add(V_Off);
+
+            f_active.RegisterValueChangedCallback(evt =>
+            {
+                f_active_dropdown.SetValueWithoutNotify(evt.newValue ? V_On : V_Off);
+            });
+            f_active_dropdown.RegisterValueChangedCallback(evt =>
+            {
+                f_active.value = evt.newValue == V_On;
+            });
 
             return uxml;
         }

--- a/Editor/Inspector/ObjectToggle/ToggledObjectEditor.uxml
+++ b/Editor/Inspector/ObjectToggle/ToggledObjectEditor.uxml
@@ -1,6 +1,7 @@
 ﻿<UXML xmlns:ui="UnityEngine.UIElements" xmlns:ed="UnityEditor.UIElements">
     <ui:VisualElement class="horizontal">
-        <ed:PropertyField name="f-active" binding-path="Active" label=""/>
         <ed:PropertyField name="f-object" binding-path="Object" label=""/>
+        <ui:Toggle name="f-active" binding-path="Active" label=""/>
+        <ui:DropdownField name="f-active-dropdown"/>
     </ui:VisualElement>
 </UXML>


### PR DESCRIPTION
Object Toggle のチェックボックスの意味が分かりづらいので ON/OFF のドロップダウンにしてみました。
位置と幅は Shape Changer に合わせています。

![image](https://github.com/user-attachments/assets/20938baf-ca84-46cd-b2fe-b6f8f7fee431)

Related: #1221