### PR TITLE
chore: remove ShapeChanger migration for beta only

### DIFF
--- a/Runtime/ReactiveObjects/ModularAvatarShapeChanger.cs
+++ b/Runtime/ReactiveObjects/ModularAvatarShapeChanger.cs
@@ -60,11 +60,6 @@ namespace nadena.dev.modular_avatar.core
     [HelpURL("https://modular-avatar.nadena.dev/docs/reference/shape-changer?lang=auto")]
     public class ModularAvatarShapeChanger : ReactiveComponent, IHaveObjReferences
     {
-        // Migration field to help with 1.10-beta series avatar data. Since this was never in a released version of MA,
-        // this migration support will be removed in 1.10.0.
-        [SerializeField] [FormerlySerializedAs("targetRenderer")] [HideInInspector]
-        private AvatarObjectReference m_targetRenderer = new();
-
         [SerializeField] [FormerlySerializedAs("Shapes")]
         private List<ChangedShape> m_shapes = new();
 
@@ -79,40 +74,6 @@ namespace nadena.dev.modular_avatar.core
             foreach (var shape in m_shapes)
             {
                 shape.Object?.Get(this);
-            }
-        }
-
-        private void OnEnable()
-        {
-            MigrateTargetRenderer();
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-            MigrateTargetRenderer();
-        }
-
-        // Migrate early versions of MASC (from Modular Avatar 1.10.0-beta.4 or earlier) to the new format, where the
-        // target renderer is stored separately for each shape.
-        // This logic will be removed in 1.10.0.
-        private void MigrateTargetRenderer()
-        {
-            // Note: This method runs in the context of OnValidate, and therefore cannot touch any other unity objects.
-            if (!string.IsNullOrEmpty(m_targetRenderer.referencePath) || m_targetRenderer.targetObject != null)
-            {
-                foreach (var shape in m_shapes)
-                {
-                    if (shape.Object == null) shape.Object = new AvatarObjectReference();
-                    
-                    if (string.IsNullOrEmpty(shape.Object.referencePath) && shape.Object.targetObject == null)
-                    {
-                        shape.Object.referencePath = m_targetRenderer.referencePath;
-                        shape.Object.targetObject = m_targetRenderer.targetObject;
-                    }
-                }
-                m_targetRenderer.referencePath = null;
-                m_targetRenderer.targetObject = null;
             }
         }
 

--- a/UnitTests~/ShapeChanger/InitialStates/SCDefaultAnimation.prefab
+++ b/UnitTests~/ShapeChanger/InitialStates/SCDefaultAnimation.prefab
@@ -46,10 +46,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_inverted: 0
   m_targetRenderer:
-    referencePath: test mesh
+    referencePath: 
     targetObject: {fileID: 0}
   m_shapes:
-  - ShapeName: key2
+  - Object:
+      referencePath: test mesh
+      targetObject: {fileID: 0}
+    ShapeName: key2
     ChangeType: 0
     Value: 100
 --- !u!1 &2598725701317979415
@@ -98,10 +101,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_inverted: 0
   m_targetRenderer:
-    referencePath: test mesh
+    referencePath: 
     targetObject: {fileID: 0}
   m_shapes:
-  - ShapeName: key1
+  - Object:
+      referencePath: test mesh
+      targetObject: {fileID: 0}
+    ShapeName: key1
     ChangeType: 1
     Value: 10
 --- !u!1 &2845086157653980983
@@ -150,10 +156,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_inverted: 0
   m_targetRenderer:
-    referencePath: test mesh
+    referencePath: 
     targetObject: {fileID: 0}
   m_shapes:
-  - ShapeName: key3
+  - Object:
+      referencePath: test mesh
+      targetObject: {fileID: 0}
+    ShapeName: key3
     ChangeType: 1
     Value: 100
 --- !u!1 &6385483934583485188
@@ -204,10 +213,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_inverted: 0
   m_targetRenderer:
-    referencePath: test mesh
+    referencePath: 
     targetObject: {fileID: 0}
   m_shapes:
-  - ShapeName: key1
+  - Object:
+      referencePath: test mesh
+      targetObject: {fileID: 0}
+    ShapeName: key1
     ChangeType: 1
     Value: 20
 --- !u!114 &2918390808850211981


### PR DESCRIPTION
ベータ期間中だけの予定だった ShapeChanger のマイグレーション処理、すっかり忘れていました。