### PR TITLE
Revert "fix: remove unnecessory exit transitions for reactive components (#1161)"

### DIFF
--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
@@ -300,8 +300,7 @@ namespace nadena.dev.modular_avatar.core.editor
             var transitionBuffer = new List<(AnimatorState, List<AnimatorStateTransition>)>();
             var entryTransitions = new List<AnimatorTransition>();
 
-            var initialStateTransitionList = new List<AnimatorStateTransition>();
-            transitionBuffer.Add((initialState, initialStateTransitionList));
+            transitionBuffer.Add((initialState, new List<AnimatorStateTransition>()));
 
             foreach (var group in info.actionGroups.Skip(lastConstant))
             {
@@ -321,30 +320,33 @@ namespace nadena.dev.modular_avatar.core.editor
 
                     var conditions = GetTransitionConditions(asc, group);
 
-                    if (!group.Inverted)
+                    foreach (var (st, transitions) in transitionBuffer)
                     {
-                        var transition = new AnimatorStateTransition
+                        if (!group.Inverted)
                         {
-                            isExit = true,
-                            hasExitTime = false,
-                            duration = 0,
-                            hasFixedDuration = true,
-                            conditions = (AnimatorCondition[])conditions.Clone()
-                        };
-                        initialStateTransitionList.Add(transition);
-                    }
-                    else
-                    {
-                        foreach (var cond in conditions)
-                        {
-                            initialStateTransitionList.Add(new AnimatorStateTransition
+                            var transition = new AnimatorStateTransition
                             {
                                 isExit = true,
                                 hasExitTime = false,
                                 duration = 0,
                                 hasFixedDuration = true,
-                                conditions = new[] { InvertCondition(cond) }
-                            });
+                                conditions = (AnimatorCondition[])conditions.Clone()
+                            };
+                            transitions.Add(transition);
+                        }
+                        else
+                        {
+                            foreach (var cond in conditions)
+                            {
+                                transitions.Add(new AnimatorStateTransition
+                                {
+                                    isExit = true,
+                                    hasExitTime = false,
+                                    duration = 0,
+                                    hasFixedDuration = true,
+                                    conditions = new[] { InvertCondition(cond) }
+                                });
+                            }
                         }
                     }
 


### PR DESCRIPTION
This reverts commit 9dfa0dae23d9d4aa6e80e9c9d691e363dc297fdc. Those
transitions are needed when controlling the same object from multiple
parameters.

Closes: #1234
