### PR TITLE
feat: add support for drag-and-drop on MaterialSetter and ShapeChanger

### DIFF
--- a/Editor/Inspector/DragAndDropManipulator.cs
+++ b/Editor/Inspector/DragAndDropManipulator.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    internal abstract class DragAndDropManipulator<T> : PointerManipulator where T : Component, IHaveObjReferences
+    {
+        private const string DragActiveClassName = "drop-area--drag-active";
+
+        public T TargetComponent { get; set; }
+
+        private Transform _avatarRoot;
+        private GameObject[] _draggingObjects = Array.Empty<GameObject>();
+
+        public DragAndDropManipulator(VisualElement targetElement, T targetComponent)
+        {
+            target = targetElement;
+            TargetComponent = targetComponent;
+        }
+
+        protected sealed override void RegisterCallbacksOnTarget()
+        {
+            target.RegisterCallback<DragEnterEvent>(OnDragEnter);
+            target.RegisterCallback<DragLeaveEvent>(OnDragLeave);
+            target.RegisterCallback<DragExitedEvent>(OnDragExited);
+            target.RegisterCallback<DragUpdatedEvent>(OnDragUpdated);
+            target.RegisterCallback<DragPerformEvent>(OnDragPerform);
+        }
+
+        protected sealed override void UnregisterCallbacksFromTarget()
+        {
+            target.UnregisterCallback<DragEnterEvent>(OnDragEnter);
+            target.UnregisterCallback<DragLeaveEvent>(OnDragLeave);
+            target.UnregisterCallback<DragExitedEvent>(OnDragExited);
+            target.UnregisterCallback<DragUpdatedEvent>(OnDragUpdated);
+            target.UnregisterCallback<DragPerformEvent>(OnDragPerform);
+        }
+
+        private void OnDragEnter(DragEnterEvent _)
+        {
+            if (TargetComponent == null) return;
+
+            _avatarRoot = RuntimeUtil.FindAvatarTransformInParents(TargetComponent.transform);
+            if (_avatarRoot == null) return;
+
+            var knownObjects = TargetComponent.GetObjectReferences().Select(x => x.Get(TargetComponent)).ToHashSet();
+            _draggingObjects = DragAndDrop.objectReferences.OfType<GameObject>()
+                .Where(x => !knownObjects.Contains(x))
+                .Where(x => RuntimeUtil.FindAvatarTransformInParents(x.transform) == _avatarRoot)
+                .Where(FilterGameObject)
+                .ToArray();
+            if (_draggingObjects.Length == 0) return;
+
+            target.AddToClassList(DragActiveClassName);
+        }
+
+        private void OnDragLeave(DragLeaveEvent _)
+        {
+            _draggingObjects = Array.Empty<GameObject>();
+            target.RemoveFromClassList(DragActiveClassName);
+        }
+
+        private void OnDragExited(DragExitedEvent _)
+        {
+            _draggingObjects = Array.Empty<GameObject>();
+            target.RemoveFromClassList(DragActiveClassName);
+        }
+
+        private void OnDragUpdated(DragUpdatedEvent _)
+        {
+            if (TargetComponent == null) return;
+            if (_avatarRoot == null) return;
+            if (_draggingObjects.Length == 0) return;
+
+            DragAndDrop.visualMode = DragAndDropVisualMode.Generic;
+        }
+
+        private void OnDragPerform(DragPerformEvent _)
+        {
+            if (TargetComponent == null) return;
+            if (_avatarRoot == null) return;
+            if (_draggingObjects.Length == 0) return;
+
+            AddObjectReferences(_draggingObjects
+                .Select(x =>
+                {
+                    var reference = new AvatarObjectReference();
+                    reference.Set(x);
+                    return reference;
+                })
+                .ToArray());
+        }
+
+        protected abstract bool FilterGameObject(GameObject obj);
+
+        protected abstract void AddObjectReferences(AvatarObjectReference[] references);
+    }
+}

--- a/Editor/Inspector/DragAndDropManipulator.cs
+++ b/Editor/Inspector/DragAndDropManipulator.cs
@@ -12,6 +12,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public T TargetComponent { get; set; }
 
+        protected virtual bool AllowKnownObjects => true;
+
         private Transform _avatarRoot;
         private GameObject[] _draggingObjects = Array.Empty<GameObject>();
 
@@ -48,7 +50,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
             var knownObjects = TargetComponent.GetObjectReferences().Select(x => x.Get(TargetComponent)).ToHashSet();
             _draggingObjects = DragAndDrop.objectReferences.OfType<GameObject>()
-                .Where(x => !knownObjects.Contains(x))
+                .Where(x => AllowKnownObjects || !knownObjects.Contains(x))
                 .Where(x => RuntimeUtil.FindAvatarTransformInParents(x.transform) == _avatarRoot)
                 .Where(FilterGameObject)
                 .ToArray();
@@ -94,7 +96,10 @@ namespace nadena.dev.modular_avatar.core.editor
                 .ToArray());
         }
 
-        protected abstract bool FilterGameObject(GameObject obj);
+        protected virtual bool FilterGameObject(GameObject obj)
+        {
+            return true;
+        }
 
         protected abstract void AddObjectReferences(AvatarObjectReference[] references);
     }

--- a/Editor/Inspector/DragAndDropManipulator.cs.meta
+++ b/Editor/Inspector/DragAndDropManipulator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 528c660b56905844ea2f88bc73837e9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/MaterialSetter/MaterialSetterEditor.cs
+++ b/Editor/Inspector/MaterialSetter/MaterialSetterEditor.cs
@@ -16,6 +16,7 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
         [SerializeField] private StyleSheet uss;
         [SerializeField] private VisualTreeAsset uxml;
 
+        private DragAndDropManipulator _dragAndDropManipulator;
 
         protected override void OnInnerInspectorGUI()
         {
@@ -37,7 +38,44 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
             listView.showBoundCollectionSize = false;
             listView.virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight;
 
+            _dragAndDropManipulator = new DragAndDropManipulator(root.Q("group-box"), target as ModularAvatarMaterialSetter);
+
             return root;
+        }
+
+        private void OnEnable()
+        {
+            if (_dragAndDropManipulator != null)
+                _dragAndDropManipulator.TargetComponent = target as ModularAvatarMaterialSetter;
+        }
+
+        private class DragAndDropManipulator : DragAndDropManipulator<ModularAvatarMaterialSetter>
+        {
+            public DragAndDropManipulator(VisualElement targetElement, ModularAvatarMaterialSetter targetComponent)
+                : base(targetElement, targetComponent) { }
+
+            protected override bool FilterGameObject(GameObject obj)
+            {
+                if (obj.TryGetComponent<Renderer>(out var renderer))
+                {
+                    return renderer.sharedMaterials.Length > 0;
+                }
+                return false;
+            }
+
+            protected override void AddObjectReferences(AvatarObjectReference[] references)
+            {
+                Undo.RecordObject(TargetComponent, "Add Material Switch Objects");
+
+                foreach (var reference in references)
+                {
+                    var materialSwitchObject = new MaterialSwitchObject { Object = reference, MaterialIndex = 0 };
+                    TargetComponent.Objects.Add(materialSwitchObject);
+                }
+
+                EditorUtility.SetDirty(TargetComponent);
+                PrefabUtility.RecordPrefabInstancePropertyModifications(TargetComponent);
+            }
         }
     }
 }

--- a/Editor/Inspector/MaterialSetter/MaterialSetterStyles.uss
+++ b/Editor/Inspector/MaterialSetter/MaterialSetterStyles.uss
@@ -62,3 +62,13 @@
 #f-material {
     flex-grow: 1;
 }
+
+.drop-area--drag-active {
+    background-color: rgba(0, 127, 255, 0.2);
+}
+
+.drop-area--drag-active .unity-scroll-view,
+.drop-area--drag-active .unity-list-view__footer,
+.drop-area--drag-active .unity-list-view__reorderable-item {
+    background-color: rgba(0, 0, 0, 0.0);
+}

--- a/Editor/Inspector/ObjectToggle/ObjectSwitcherEditor.cs
+++ b/Editor/Inspector/ObjectToggle/ObjectSwitcherEditor.cs
@@ -55,10 +55,7 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
             public DragAndDropManipulator(VisualElement targetElement, ModularAvatarObjectToggle targetComponent)
                 : base(targetElement, targetComponent) { }
 
-            protected override bool FilterGameObject(GameObject obj)
-            {
-                return true;
-            }
+            protected override bool AllowKnownObjects => false;
 
             protected override void AddObjectReferences(AvatarObjectReference[] references)
             {

--- a/Editor/Inspector/ObjectToggle/ObjectSwitcherEditor.cs
+++ b/Editor/Inspector/ObjectToggle/ObjectSwitcherEditor.cs
@@ -35,13 +35,11 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
             ROSimulatorButton.BindRefObject(root, target);
 
             var listView = root.Q<ListView>("Shapes");
-            _dragAndDropManipulator = new DragAndDropManipulator(listView)
-            {
-                TargetComponent = target as ModularAvatarObjectToggle
-            };
 
             listView.showBoundCollectionSize = false;
             listView.virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight;
+
+            _dragAndDropManipulator = new DragAndDropManipulator(root.Q("group-box"), target as ModularAvatarObjectToggle);
 
             return root;
         }
@@ -52,91 +50,28 @@ namespace nadena.dev.modular_avatar.core.editor.ShapeChanger
                 _dragAndDropManipulator.TargetComponent = target as ModularAvatarObjectToggle;
         }
 
-        private class DragAndDropManipulator : PointerManipulator
+        private class DragAndDropManipulator : DragAndDropManipulator<ModularAvatarObjectToggle>
         {
-            public ModularAvatarObjectToggle TargetComponent;
-            private GameObject[] _nowDragging = Array.Empty<GameObject>();
-            private Transform _avatarRoot;
+            public DragAndDropManipulator(VisualElement targetElement, ModularAvatarObjectToggle targetComponent)
+                : base(targetElement, targetComponent) { }
 
-            private readonly VisualElement _parentElem;
-
-            public DragAndDropManipulator(VisualElement target)
+            protected override bool FilterGameObject(GameObject obj)
             {
-                this.target = target;
-                _parentElem = target.parent;
+                return true;
             }
 
-            protected override void RegisterCallbacksOnTarget()
+            protected override void AddObjectReferences(AvatarObjectReference[] references)
             {
-                target.RegisterCallback<DragEnterEvent>(OnDragEnter);
-                target.RegisterCallback<DragLeaveEvent>(OnDragLeave);
-                target.RegisterCallback<DragPerformEvent>(OnDragPerform);
-                target.RegisterCallback<DragUpdatedEvent>(OnDragUpdate);
-            }
+                Undo.RecordObject(TargetComponent, "Add Toggled Objects");
 
-            protected override void UnregisterCallbacksFromTarget()
-            {
-                target.UnregisterCallback<DragEnterEvent>(OnDragEnter);
-                target.UnregisterCallback<DragLeaveEvent>(OnDragLeave);
-                target.UnregisterCallback<DragPerformEvent>(OnDragPerform);
-                target.RegisterCallback<DragUpdatedEvent>(OnDragUpdate);
-            }
-
-
-            private void OnDragEnter(DragEnterEvent evt)
-            {
-                if (TargetComponent == null) return;
-
-                _avatarRoot = RuntimeUtil.FindAvatarTransformInParents(TargetComponent.transform);
-                if (_avatarRoot == null) return;
-
-                _nowDragging = DragAndDrop.objectReferences.OfType<GameObject>()
-                    .Where(o => RuntimeUtil.FindAvatarTransformInParents(o.transform) == _avatarRoot)
-                    .ToArray();
-
-                if (_nowDragging.Length > 0)
+                foreach (var reference in references)
                 {
-                    DragAndDrop.visualMode = DragAndDropVisualMode.Link;
-
-                    _parentElem.AddToClassList("drop-area--drag-active");
-                }
-            }
-
-            private void OnDragUpdate(DragUpdatedEvent _)
-            {
-                if (_nowDragging.Length > 0) DragAndDrop.visualMode = DragAndDropVisualMode.Link;
-            }
-
-            private void OnDragLeave(DragLeaveEvent evt)
-            {
-                _nowDragging = Array.Empty<GameObject>();
-                _parentElem.RemoveFromClassList("drop-area--drag-active");
-            }
-
-            private void OnDragPerform(DragPerformEvent evt)
-            {
-                if (_nowDragging.Length > 0 && TargetComponent != null && _avatarRoot != null)
-                {
-                    var knownObjs = TargetComponent.Objects.Select(o => o.Object.Get(TargetComponent)).ToHashSet();
-
-                    Undo.RecordObject(TargetComponent, "Add Toggled Objects");
-                    foreach (var obj in _nowDragging)
-                    {
-                        if (knownObjs.Contains(obj)) continue;
-
-                        var aor = new AvatarObjectReference();
-                        aor.Set(obj);
-
-                        var toggledObject = new ToggledObject { Object = aor, Active = !obj.activeSelf };
-                        TargetComponent.Objects.Add(toggledObject);
-                    }
-
-                    EditorUtility.SetDirty(TargetComponent);
-                    PrefabUtility.RecordPrefabInstancePropertyModifications(TargetComponent);
+                    var toggledObject = new ToggledObject { Object = reference, Active = !reference.Get(TargetComponent).activeSelf };
+                    TargetComponent.Objects.Add(toggledObject);
                 }
 
-                _nowDragging = Array.Empty<GameObject>();
-                _parentElem.RemoveFromClassList("drop-area--drag-active");
+                EditorUtility.SetDirty(TargetComponent);
+                PrefabUtility.RecordPrefabInstancePropertyModifications(TargetComponent);
             }
         }
     }

--- a/Editor/Inspector/ObjectToggle/ObjectSwitcherStyles.uss
+++ b/Editor/Inspector/ObjectToggle/ObjectSwitcherStyles.uss
@@ -51,6 +51,12 @@
     width: 60px;
 }
 
-.drop-area--drag-active > ListView ScrollView {
-    background-color: rgba(0, 255, 255, 0.1);
+.drop-area--drag-active {
+    background-color: rgba(0, 127, 255, 0.2);
+}
+
+.drop-area--drag-active .unity-scroll-view,
+.drop-area--drag-active .unity-list-view__footer,
+.drop-area--drag-active .unity-list-view__reorderable-item {
+    background-color: rgba(0, 0, 0, 0.0);
 }

--- a/Editor/Inspector/ShapeChanger/ShapeChangerStyles.uss
+++ b/Editor/Inspector/ShapeChanger/ShapeChangerStyles.uss
@@ -68,3 +68,13 @@
 .change-type-delete #f-value-delete {
     display: flex;
 }
+
+.drop-area--drag-active {
+    background-color: rgba(0, 127, 255, 0.2);
+}
+
+.drop-area--drag-active .unity-scroll-view,
+.drop-area--drag-active .unity-list-view__footer,
+.drop-area--drag-active .unity-list-view__reorderable-item {
+    background-color: rgba(0, 0, 0, 0.0);
+}


### PR DESCRIPTION
MA Material Setter と MA Shape Changer の D&D 対応です。
MA Object Toggle と共通化しています。

リストが空でないときに範囲が狭すぎてドロップしづらかったので外枠まで広げてみました。
マウスカーソルが映っていませんがドロップしようとしているときのスクショです。
![名称未設定](https://github.com/user-attachments/assets/0f65db15-62e1-4cd0-a401-c581425a0451)