### PR TITLE
chore: Fix non-VRChat support (for MA 1.10.5)

### DIFF
--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -158,6 +158,7 @@ namespace nadena.dev.modular_avatar.animation
 
 #if MA_VRCSDK3_AVATARS
             var avatarDescriptor = context.AvatarDescriptor;
+            if (!avatarDescriptor) return;
 
             foreach (var layer in avatarDescriptor.baseAnimationLayers)
             {

--- a/Editor/Animation/AnimationServicesContext.cs
+++ b/Editor/Animation/AnimationServicesContext.cs
@@ -92,6 +92,8 @@ namespace nadena.dev.modular_avatar.animation
         public void AddPropertyDefinition(AnimatorControllerParameter paramDef)
         {
 #if MA_VRCSDK3_AVATARS
+            if (!_context.AvatarDescriptor) return;
+
             var fx = (AnimatorController)
                 _context.AvatarDescriptor.baseAnimationLayers
                 .First(l => l.type == VRCAvatarDescriptor.AnimLayerType.FX)

--- a/Editor/Animation/AnimationUtil.cs
+++ b/Editor/Animation/AnimationUtil.cs
@@ -53,6 +53,8 @@ namespace nadena.dev.modular_avatar.animation
             // This helps reduce the risk that we'll accidentally modify the original assets.
 
 #if MA_VRCSDK3_AVATARS
+            if (!context.AvatarDescriptor) return;
+
             context.AvatarDescriptor.baseAnimationLayers =
                 CloneLayers(context, context.AvatarDescriptor.baseAnimationLayers);
             context.AvatarDescriptor.specialAnimationLayers =

--- a/Editor/Animation/PathMappings.cs
+++ b/Editor/Animation/PathMappings.cs
@@ -369,21 +369,24 @@ namespace nadena.dev.modular_avatar.animation
             Profiler.EndSample();
 
 #if MA_VRCSDK3_AVATARS
-            var layers = context.AvatarDescriptor.baseAnimationLayers
-                .Concat(context.AvatarDescriptor.specialAnimationLayers);
-
-            Profiler.BeginSample("ApplyMappingsToAvatarMasks");
-            foreach (var layer in layers)
+            if (context.AvatarDescriptor)
             {
-                ApplyMappingsToAvatarMask(layer.mask);
+                var layers = context.AvatarDescriptor.baseAnimationLayers
+                    .Concat(context.AvatarDescriptor.specialAnimationLayers);
 
-                if (layer.animatorController is AnimatorController ac)
-                    // By this point, all AnimationOverrideControllers have been collapsed into an ephemeral
-                    // AnimatorController so we can safely modify the controller in-place.
-                    foreach (var acLayer in ac.layers)
-                        ApplyMappingsToAvatarMask(acLayer.avatarMask);
+                Profiler.BeginSample("ApplyMappingsToAvatarMasks");
+                foreach (var layer in layers)
+                {
+                    ApplyMappingsToAvatarMask(layer.mask);
+
+                    if (layer.animatorController is AnimatorController ac)
+                        // By this point, all AnimationOverrideControllers have been collapsed into an ephemeral
+                        // AnimatorController so we can safely modify the controller in-place.
+                        foreach (var acLayer in ac.layers)
+                            ApplyMappingsToAvatarMask(acLayer.avatarMask);
+                }
+                Profiler.EndSample();
             }
-            Profiler.EndSample();
 #endif
             
             Profiler.EndSample();

--- a/Editor/FixupPasses/FixupExpressionsMenuPass.cs
+++ b/Editor/FixupPasses/FixupExpressionsMenuPass.cs
@@ -19,6 +19,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal static void FixupExpressionsMenu(BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             context.AvatarDescriptor.customExpressions = true;
 
             var expressionsMenu = context.AvatarDescriptor.expressionsMenu;

--- a/Editor/MergeAnimatorProcessor.cs
+++ b/Editor/MergeAnimatorProcessor.cs
@@ -65,6 +65,7 @@ namespace nadena.dev.modular_avatar.core.editor
             mergeSessions.Clear();
 
             var descriptor = avatarGameObject.GetComponent<VRCAvatarDescriptor>();
+            if (!descriptor) return;
 
             if (descriptor.baseAnimationLayers != null) InitSessions(descriptor.baseAnimationLayers);
             if (descriptor.specialAnimationLayers != null) InitSessions(descriptor.specialAnimationLayers);

--- a/Editor/OptimizationPasses/PruneParametersPass.cs
+++ b/Editor/OptimizationPasses/PruneParametersPass.cs
@@ -9,6 +9,8 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             var expParams = context.AvatarDescriptor.expressionParameters;
             if (expParams != null && context.IsTemporaryAsset(expParams))
             {

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
@@ -34,6 +34,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal void Execute()
         {
+            if (!context.AvatarDescriptor) return;
+
             // Having a WD OFF layer after WD ON layers can break WD. We match the behavior of the existing states,
             // and if mixed, use WD ON to maximize compatibility.
             _writeDefaults = MergeAnimatorProcessor.ProbeWriteDefaults(FindFxController().animatorController as AnimatorController) ?? true;

--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -159,6 +159,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public void OnPreprocessAvatar(GameObject avatar, BuildContext context)
         {
+            if (!context.AvatarDescriptor) return;
+
             _context = context;
 
             var syncParams = WalkTree(avatar);

--- a/UnitTests~/Animation/AnimParameterPathRewrite/AnimParameterPathRewritingTest.cs
+++ b/UnitTests~/Animation/AnimParameterPathRewrite/AnimParameterPathRewritingTest.cs
@@ -1,4 +1,6 @@
-﻿using nadena.dev.modular_avatar.core.editor;
+﻿#if MA_VRCSDK3_AVATARS
+
+using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -37,3 +39,5 @@ namespace modular_avatar_tests
         }
     }
 }
+
+#endif

--- a/UnitTests~/Animation/AvatarMask/AvatarMaskTest.cs
+++ b/UnitTests~/Animation/AvatarMask/AvatarMaskTest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.ndmf;
@@ -159,3 +161,5 @@ namespace modular_avatar_tests
         }
     }
 }
+
+#endif

--- a/UnitTests~/Animation/BaseLayerReferenceCorrection/BaseLayerReferenceCorrectionTest.cs
+++ b/UnitTests~/Animation/BaseLayerReferenceCorrection/BaseLayerReferenceCorrectionTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Linq;
 using nadena.dev.ndmf;
 using NUnit.Framework;
 using UnityEditor.Animations;
@@ -27,3 +29,5 @@ namespace modular_avatar_tests
         }
     }
 }
+
+#endif

--- a/UnitTests~/Animation/PlayAudio/PlayAudioRemapping.cs
+++ b/UnitTests~/Animation/PlayAudio/PlayAudioRemapping.cs
@@ -1,9 +1,10 @@
-﻿using nadena.dev.modular_avatar.core.editor;
+﻿#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
+
+using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
 using UnityEditor.Animations;
 using VRC.SDK3.Avatars.Components;
 
-#if MA_VRCSDK3_AVATARS_3_5_2_OR_NEWER
 namespace modular_avatar_tests
 {
     public class PlayAudioRemapping : TestBase
@@ -28,4 +29,5 @@ namespace modular_avatar_tests
         }
     }
 }
+
 #endif

--- a/UnitTests~/MergeAnimatorTests/MergeSingleTests.cs
+++ b/UnitTests~/MergeAnimatorTests/MergeSingleTests.cs
@@ -1,4 +1,6 @@
-﻿using modular_avatar_tests;
+﻿#if MA_VRCSDK3_AVATARS
+
+using modular_avatar_tests;
 using nadena.dev.modular_avatar.animation;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.modular_avatar.core.editor;
@@ -48,3 +50,5 @@ namespace UnitTests.MergeAnimatorTests
         }
     }
 }
+
+#endif

--- a/UnitTests~/MergeAnimatorTests/PreexistingAnimatorParams/PreexistingParamsTest.cs
+++ b/UnitTests~/MergeAnimatorTests/PreexistingAnimatorParams/PreexistingParamsTest.cs
@@ -1,3 +1,5 @@
+#if MA_VRCSDK3_AVATARS
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -35,3 +37,4 @@ public class PreexistingParamsTest : TestBase
     }
 }
 
+#endif

--- a/UnitTests~/MergeAnimatorTests/ProxyAnim/ProxyAnimTest.cs
+++ b/UnitTests~/MergeAnimatorTests/ProxyAnim/ProxyAnimTest.cs
@@ -1,4 +1,6 @@
-﻿using modular_avatar_tests;
+﻿#if MA_VRCSDK3_AVATARS
+
+using modular_avatar_tests;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
@@ -26,3 +28,5 @@ namespace UnitTests.MergeAnimatorTests.ProxyAnim
         }
     }
 }
+
+#endif

--- a/UnitTests~/MergeAnimatorTests/SyncedLayerOverrideInSubStatemachine/SyncedLayerOverrideInSubStateMachine.cs
+++ b/UnitTests~/MergeAnimatorTests/SyncedLayerOverrideInSubStatemachine/SyncedLayerOverrideInSubStateMachine.cs
@@ -1,4 +1,6 @@
-﻿using modular_avatar_tests;
+﻿#if MA_VRCSDK3_AVATARS
+
+using modular_avatar_tests;
 using nadena.dev.ndmf;
 using NUnit.Framework;
 using UnityEditor.Animations;
@@ -39,3 +41,5 @@ namespace UnitTests.MergeAnimatorTests.SyncedLayerOverrideInSubStatemachine
         }
     }
 }
+
+#endif

--- a/UnitTests~/MergeAnimatorTests/TypeAdjustment/ConvertTransitionTypes.cs
+++ b/UnitTests~/MergeAnimatorTests/TypeAdjustment/ConvertTransitionTypes.cs
@@ -1,3 +1,5 @@
+#if MA_VRCSDK3_AVATARS
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -268,3 +270,4 @@ public class ConvertTransitionTypes : TestBase
     }
 }
 
+#endif

--- a/UnitTests~/MergeDBT/MergeDirectBlendTreeTests.cs
+++ b/UnitTests~/MergeDBT/MergeDirectBlendTreeTests.cs
@@ -1,3 +1,5 @@
+#if MA_VRCSDK3_AVATARS
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -24,3 +26,5 @@ public class MergeDirectBlendTreeTests : TestBase
         Assert.AreEqual(0, parameters["DEF"]);
     }
 }
+
+#endif

--- a/UnitTests~/ReactiveComponent/BlendshapeSyncTest.cs
+++ b/UnitTests~/ReactiveComponent/BlendshapeSyncTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Linq;
 using modular_avatar_tests;
 using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
@@ -59,3 +61,5 @@ namespace UnitTests.ReactiveComponent
         }
     }
 }
+
+#endif

--- a/UnitTests~/ReactiveComponent/ObjectToggleTests.cs
+++ b/UnitTests~/ReactiveComponent/ObjectToggleTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Linq;
 using modular_avatar_tests;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.modular_avatar.core.editor;
@@ -48,3 +50,5 @@ namespace UnitTests.ReactiveComponent
         }
     }
 }
+
+#endif

--- a/UnitTests~/ReactiveComponent/ParameterAssignment/AutoValueAssignmentTests.cs
+++ b/UnitTests~/ReactiveComponent/ParameterAssignment/AutoValueAssignmentTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using modular_avatar_tests;
@@ -113,3 +115,5 @@ namespace UnitTests.ReactiveComponent.ParameterAssignment
         }
     }
 }
+
+#endif

--- a/UnitTests~/ReactiveComponent/ParameterAssignment/ParameterTypeTests.cs
+++ b/UnitTests~/ReactiveComponent/ParameterAssignment/ParameterTypeTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Linq;
 using modular_avatar_tests;
 using nadena.dev.modular_avatar.core;
@@ -83,3 +85,5 @@ namespace UnitTests.ReactiveComponent.ParameterAssignment
         }
     }
 }
+
+#endif

--- a/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
+++ b/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
@@ -1,3 +1,5 @@
+#if MA_VRCSDK3_AVATARS
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -96,3 +98,5 @@ public class ShapeDeletionAnalysis : TestBase
         Assert.AreEqual(originalSharedMesh, mesh.sharedMesh);
     }
 }
+
+#endif

--- a/UnitTests~/ShapeChanger/InitialStates/SCDefaultAnimation.cs
+++ b/UnitTests~/ShapeChanger/InitialStates/SCDefaultAnimation.cs
@@ -1,4 +1,6 @@
-﻿using modular_avatar_tests;
+﻿#if MA_VRCSDK3_AVATARS
+
+using modular_avatar_tests;
 using nadena.dev.modular_avatar.animation;
 using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
@@ -122,3 +124,5 @@ namespace ShapeChangerTests
         }
     }
 }
+
+#endif

--- a/UnitTests~/VisibleHeadAccessoryTest/VisibleHeadAccessoryTest.cs
+++ b/UnitTests~/VisibleHeadAccessoryTest/VisibleHeadAccessoryTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -58,3 +60,5 @@ namespace UnitTests.VisibleHeadAccessoryTest
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Improved non-VRChat projects and non-VRChat avatars (in VRCSDK projects) support, but for MA 1.10.5.