### PR TITLE
ui: Improvements to MA Parameters editor

### DIFF
--- a/Editor/Inspector/Parameters/ParameterConfigDrawer.cs
+++ b/Editor/Inspector/Parameters/ParameterConfigDrawer.cs
@@ -81,6 +81,12 @@ namespace nadena.dev.modular_avatar.core.editor.Parameters
 
             updateRemapToPlaceholder();
 
+            foreach (var elem in root.Query<TextElement>().Build())
+            {
+                // Prevent keypresses from bubbling up
+                elem.RegisterCallback<KeyDownEvent>(evt => evt.StopPropagation(), TrickleDown.NoTrickleDown);
+            }
+
             return root;
         }
 

--- a/Editor/Inspector/Parameters/Parameters.uss
+++ b/Editor/Inspector/Parameters/Parameters.uss
@@ -1,5 +1,6 @@
 ﻿#ListViewContainer {
     margin-top: 4px;
+    max-height: 500px;
 }
 
 .horizontal {

--- a/Editor/Inspector/Parameters/ParametersMainUI.uxml
+++ b/Editor/Inspector/Parameters/ParametersMainUI.uxml
@@ -12,7 +12,6 @@
             show-border="true"
             show-foldout-header="false"
             name="Parameters"
-            item-height="100"
             binding-path="parameters" 
             style="flex-grow: 1;"
         />
@@ -32,6 +31,8 @@
             style="flex-grow: 1;"
             />
     </ui:Foldout>
+    
+    <editor:ObjectField name="p_import" label="merge_parameter.ui.importFromAsset" class="ndmf-tr"/>
     
     <ma:LanguageSwitcherElement/>
 </UXML>

--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -51,6 +51,7 @@
   "merge_parameter.ui.add_button": "Add",
   "merge_parameter.ui.details": "Parameter Configuration",
   "merge_parameter.ui.overrideAnimatorDefaults": "Override Animator Defaults",
+  "merge_parameter.ui.importFromAsset": "Import from asset",
   "merge_armature.merge_target": "Merge Target",
   "merge_armature.merge_target.tooltip": "The armature (or subtree) to merge this object into",
   "merge_armature.prefix": "Prefix",


### PR DESCRIPTION
* Add import-from-asset feature (Closes: #880, #668, #410)
* Limit size of scrollable area to avoid double-scrolling
* Add support for pressing the "delete" key to delete parameters.
