### PR TITLE
fix: MA MergeArmature forget to retaining the root bone.

### DIFF
--- a/Editor/MergeArmatureHook.cs
+++ b/Editor/MergeArmatureHook.cs
@@ -116,9 +116,23 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 RetainBoneReferences(c as Component);
             }
+            
             foreach (var smr in avatarGameObject.transform.GetComponentsInChildren<SkinnedMeshRenderer>(true))
             {
-                BoneDatabase.RetainMergedBone(smr.rootBone);
+                // If the root bone has been offset, or has a different sign for its scale, we need to retain it.
+                // see https://github.com/bdunderscore/modular-avatar/pull/1355
+                // (we avoid retaining otherwise to avoid excess bone transforms)
+
+                if (smr.rootBone == null || smr.rootBone.parent == null) continue;
+
+                var root = smr.rootBone;
+                var parent = root.parent;
+
+                if ((parent.position - root.position).sqrMagnitude > 0.000001f
+                    || Vector3.Dot(parent.localScale.normalized, root.localScale.normalized) < 0.9999f)
+                {
+                    BoneDatabase.RetainMergedBone(smr.rootBone);
+                }
             }
 
             new RetargetMeshes().OnPreprocessAvatar(avatarGameObject, BoneDatabase, PathMappings);

--- a/Editor/MergeArmatureHook.cs
+++ b/Editor/MergeArmatureHook.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2022 bd_
@@ -115,6 +115,10 @@ namespace nadena.dev.modular_avatar.core.editor
             foreach (var c in avatarGameObject.transform.GetComponentsInChildren<IConstraint>(true))
             {
                 RetainBoneReferences(c as Component);
+            }
+            foreach (var smr in avatarGameObject.transform.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            {
+                BoneDatabase.RetainMergedBone(smr.rootBone);
             }
 
             new RetargetMeshes().OnPreprocessAvatar(avatarGameObject, BoneDatabase, PathMappings);


### PR DESCRIPTION
[ctx-TreeRoot](https://misskey.niri.la/notes/a0ooh9xb8m)
[ctx](https://misskey.niri.la/notes/a0oserkoxu)

SkinnedMeshRenderer では RootBone のスケールが奇数個反転しているか否かは重要なパラメーターのようで、この部分のが奇数個反転していると Unity は カリングを反転させるようです。

スケールの反転を Mesh の方は(おそらくBonePoseを)補正することで問題がないように見えますが、RootBone は補正できないので、 RootBone を保持するようにする PR です！