### PR TITLE
Revert "Use VRCParentConstraint instead of constraint hack for world fixed objects when available (#1326)"

### DIFF
--- a/Editor/WorldFixedObjectProcessor.cs
+++ b/Editor/WorldFixedObjectProcessor.cs
@@ -86,15 +86,6 @@ namespace nadena.dev.modular_avatar.core.editor
             obj.transform.localRotation = Quaternion.identity;
             obj.transform.localScale = Vector3.one;
 
-            if (!TryCreateVRCConstraint(avatarRoot, obj)) CreateConstraint(obj, fixedGameObject);
-
-            _proxy = obj.transform;
-
-            return obj.transform;
-        }
-
-        private void CreateConstraint(GameObject obj, GameObject fixedGameObject)
-        {
             var constraint = obj.AddComponent<ParentConstraint>();
             constraint.AddSource(new ConstraintSource()
             {
@@ -105,31 +96,10 @@ namespace nadena.dev.modular_avatar.core.editor
             constraint.locked = true;
             constraint.rotationOffsets = new[] {Vector3.zero};
             constraint.translationOffsets = new[] {Vector3.zero};
-        }
 
-#if MA_VRCSDK3_AVATARS_3_7_0_OR_NEWER
-        private bool TryCreateVRCConstraint(Transform avatarRoot, GameObject obj)
-        {
-            var isVrcAvatar = avatarRoot.TryGetComponent(out VRC.SDKBase.VRC_AvatarDescriptor _);
-            
-            if (!isVrcAvatar) return false;
+            _proxy = obj.transform;
 
-            var constraint = obj.AddComponent(
-                System.Type.GetType("VRC.SDK3.Dynamics.Constraint.Components.VRCParentConstraint, VRC.SDK3.Dynamics.Constraint")
-            ) as VRC.Dynamics.ManagedTypes.VRCParentConstraintBase;
-            constraint.IsActive = true;
-            constraint.Locked = true;
-            constraint.AffectsPositionX = true;
-            constraint.AffectsPositionY = true;
-            constraint.AffectsPositionZ = true;
-            constraint.AffectsRotationX = true;
-            constraint.AffectsRotationY = true;
-            constraint.AffectsRotationZ = true;
-            constraint.FreezeToWorld = true;
-            return true;
+            return obj.transform;
         }
-#else
-        private bool TryCreateVRCConstraint(Transform avatarRoot, GameObject obj) => false;
-#endif
     }
 }

--- a/UnitTests~/WorldFixedObjectTest/WorldFixedObjectTest.cs
+++ b/UnitTests~/WorldFixedObjectTest/WorldFixedObjectTest.cs
@@ -3,7 +3,6 @@ using nadena.dev.modular_avatar.animation;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.modular_avatar.core.editor;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.Animations;
 
 public class WorldFixedObjectTest : TestBase
@@ -26,16 +25,7 @@ public class WorldFixedObjectTest : TestBase
 
         // fixed root is created
         Assert.That(fixedRoot, Is.Not.Null);
-        bool isVrcAvatar = false;
-        System.Type vrcParentConstraintType = null;
-        #if MA_VRCSDK3_AVATARS
-        isVrcAvatar = avatar.TryGetComponent(out VRC.SDKBase.VRC_AvatarDescriptor _);
-        vrcParentConstraintType = System.Type.GetType("VRC.SDK3.Dynamics.Constraint.Components.VRCParentConstraint, VRC.SDK3.Dynamics.Constraint");
-        #endif
-        Component constraint = isVrcAvatar && vrcParentConstraintType != null ?
-            fixedRoot.GetComponent(vrcParentConstraintType) :
-            fixedRoot.GetComponent<ParentConstraint>();
-        Assert.That(constraint, Is.Not.Null);
+        Assert.That(fixedRoot.GetComponent<ParentConstraint>(), Is.Not.Null);
 
         // objects are moved to fixed root
         Assert.That(movedFixedObject, Is.Not.Null);
@@ -62,16 +52,7 @@ public class WorldFixedObjectTest : TestBase
 
         // fixed root is created
         Assert.That(fixedRoot, Is.Not.Null);
-        bool isVrcAvatar = false;
-        System.Type vrcParentConstraintType = null;
-        #if MA_VRCSDK3_AVATARS
-        isVrcAvatar = avatar.TryGetComponent(out VRC.SDKBase.VRC_AvatarDescriptor _);
-        vrcParentConstraintType = System.Type.GetType("VRC.SDK3.Dynamics.Constraint.Components.VRCParentConstraint, VRC.SDK3.Dynamics.Constraint");
-        #endif
-        Component constraint = isVrcAvatar && vrcParentConstraintType != null ?
-            fixedRoot.GetComponent(vrcParentConstraintType) :
-            fixedRoot.GetComponent<ParentConstraint>();
-        Assert.That(constraint, Is.Not.Null);
+        Assert.That(fixedRoot.GetComponent<ParentConstraint>(), Is.Not.Null);
 
         // objects are moved to fixed root
         Assert.That(movedFixedObject, Is.Not.Null);


### PR DESCRIPTION
This reverts commit a984cf86735170d075f8224dd7c83fa760e54eed. The prior
behavior was to lock world fixed objects at their offset from the
origin; however with this change we ended up locking them at a location
relative to the avatar spawn location, breaking some gimmicks.

I tried experimenting a bit with VRCConstraint to try to replicate this
behavior, but it seems a bit non-trivial, so we'll revert this as a
hotfix for now.
