### PR TITLE
perf: skip some preview process for ScaleAdjuster and RemoveVertexColor

### DIFF
--- a/Editor/MiscPreview/RemoveVertexColorPreview.cs
+++ b/Editor/MiscPreview/RemoveVertexColorPreview.cs
@@ -18,7 +18,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext context)
         {
-            var roots = context.GetAvatarRoots();
+            var roots = context.GetAvatarRoots()
+                .Where(r => context.ActiveInHierarchy(r) is true);
             var removers = roots
                 .SelectMany(r => context.GetComponentsInChildren<ModularAvatarRemoveVertexColor>(r, true))
                 .Select(rvc => (ToPathString(context, rvc.transform),

--- a/Editor/ScaleAdjuster/ScaleAdjusterPreview.cs
+++ b/Editor/ScaleAdjuster/ScaleAdjusterPreview.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -63,6 +63,11 @@ namespace nadena.dev.modular_avatar.core.editor
 
             foreach (var root in ctx.GetAvatarRoots())
             {
+                if (ctx.ActiveInHierarchy(root) is false)
+                {
+                    continue;
+                }
+
                 if (ctx.GetComponentsInChildren<ModularAvatarScaleAdjuster>(root, true).Length == 0)
                 {
                     continue;

--- a/Editor/ScaleAdjuster/ScaleAdjusterPreview.cs
+++ b/Editor/ScaleAdjuster/ScaleAdjusterPreview.cs
@@ -1,4 +1,4 @@
-#region
+﻿#region
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -56,8 +56,6 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext ctx)
         {
-            var scaleAdjusters = ctx.GetComponentsByType<ModularAvatarScaleAdjuster>();
-
             var avatarToRenderer =
                 new Dictionary<GameObject, HashSet<Renderer>>();
 


### PR DESCRIPTION
ScaleAdjusterとRemoveVertexColorのNDMF Preview GetTargetGroupsにおける多少のパフォーマンス改善を行うPRです。
自分の環境ではそれぞれおよそ60msから20msほどに短縮しています。

817390a950c6fc40abb775032393fad4843cde60 ではInactiveなRoot以下を処理の対象から除外しています。(`ctx.ActiveInHierarchy(root)`でobserveするので問題ないはず)
83843e039c366129ce349d6ecad9b0ebb837286d では不要と思われる行を削除しました(パフォーマンスへの影響は小さいと思います。不要なscaleAdjustersの取得を行っており、observeも後の行の`ctx.GetComponentsInChildren<ModularAvatarScaleAdjuster>`で行われていると思います。)

こちらの勘違いがあったらcloseしてもらって大丈夫です :bow:
