### PR TITLE
feat: support merging humanoid bones with PBs in limited cases

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#1483] Merge Animator の 「アバターの Write Defaults 設定に合わせる」設定では、Additiveなレイヤー、および単一Stateかつ遷移のないレイヤー
 　に対してはWrite Defaultsを調整しないように変更。
+- [#1429] Merge Armature は、特定の場合にPhysBoneに指定されたヒューマノイドボーンをマージできるようになりました。
+  - 具体的には、子ヒューマノイドボーンがある場合はPhysBoneから除外される必要があります。
 
 ### Removed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#1483] The Merge Animator "Match Avatar Write Defaults" option will no longer adjust write defaults on states in
   additive layers, or layers with only one state and no transitions.
+- [#1429] Merge Armature will now allow you to merge humanoid bones with PhysBones attached in certain cases.
+    - Specifically, child humanoid bones (if there are any) must be excluded from all attached Physbones.
 
 ### Removed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -20,6 +20,8 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 - [#1476] ModularAvatarMergeAnimator と ModularAvatarMergeParameter を新しい NDMF API (`IVirtualizeMotion` と `IVirtualizeAnimatorController`) を使用するように変更
 - [#1483] Merge Animator の 「アバターの Write Defaults 設定に合わせる」設定では、Additiveなレイヤー、および単一Stateかつ遷移のないレイヤー
 　に対してはWrite Defaultsを調整しないように変更。
+- [#1429] Merge Armature は、特定の場合にPhysBoneに指定されたヒューマノイドボーンをマージできるようになりました。
+  - 具体的には、子ヒューマノイドボーンがある場合はPhysBoneから除外される必要があります。
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1476] Switch ModularAvatarMergeAnimator and ModularAvatarMergeParameter to use new NDMF APIs (`IVirtualizeMotion` and `IVirtualizeAnimatorController`)
 - [#1483] The Merge Animator "Match Avatar Write Defaults" option will no longer adjust write defaults on states in
   additive layers, or layers with only one state and no transitions.
+- [#1429] Merge Armature will now allow you to merge humanoid bones with PhysBones attached in certain cases.
+  - Specifically, child humanoid bones (if there are any) must be excluded from all attached Physbones. 
 
 ### Removed
 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping.cs
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping.cs
@@ -1,8 +1,13 @@
 ﻿#if MA_VRCSDK3_AVATARS
 
+using nadena.dev.modular_avatar.animation;
 using nadena.dev.modular_avatar.core.editor;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.animator;
 using NUnit.Framework;
+using UnityEngine;
 using VRC.SDK3.Dynamics.PhysBone.Components;
+using AvatarProcessor = nadena.dev.modular_avatar.core.editor.AvatarProcessor;
 
 namespace modular_avatar_tests.DuplicatePBStripping
 {
@@ -65,6 +70,84 @@ namespace modular_avatar_tests.DuplicatePBStripping
             // Note that this prefab has a pair of PhysBones whose names match but are more than 1mm apart.
             // They should not be merged to preserve intentionally attached PhysBone, which is not copied from the avatar.
             Assert.AreEqual(2, prefab.GetComponentsInChildren<VRCPhysBone>().Length);
+        }
+
+        [Test]
+        public void AcceptsHumanoidPB_OnTipBones()
+        {
+            var prefab = CreatePrefab("DuplicatePBStripping_HumanoidTip.prefab");
+            AvatarProcessor.ProcessAvatar(prefab);
+
+            var head = prefab.transform.Find("Armature/Hips/Spine/Chest/Neck/Head");
+            Transform subHead = null;
+            
+            foreach (Transform t in head)
+            {
+                if (t.gameObject.name.StartsWith("Head$"))
+                {
+                    subHead = t;
+                    break;
+                }
+            }
+            
+            Assert.NotNull(subHead);
+            
+            Assert.AreEqual(1, subHead.childCount);
+            Assert.IsTrue(subHead.TryGetComponent<VRCPhysBone>(out _));
+        }
+
+        [Test]
+        public void RejectsHumanoidPB_OnInnerBones()
+        {
+            var prefab = CreatePrefab("DuplicatePBStripping_HumanoidInner.prefab");
+
+            var context = CreateContext(prefab);
+            
+            context.ActivateExtensionContext<ModularAvatarContext>();
+            context.ActivateExtensionContextRecursive<AnimatorServicesContext>();
+            var errors = ErrorReport.CaptureErrors(() => new MergeArmatureHook().OnPreprocessAvatar(context, prefab));
+            Assert.AreEqual(1, errors.Count);
+
+            var error = errors[0];
+            Assert.AreEqual("error.merge_armature.physbone_on_humanoid_bone", ((SimpleError)error.TheError).TitleKey);
+        }
+
+        [Test]
+        public void AcceptsHumanoidPB_OnInnerBones_WithPBIgnores()
+        {
+            var prefab = CreatePrefab("DuplicatePBStripping_HumanoidInner_Ignored.prefab");
+
+            AssertInnerBones(prefab);
+        }
+
+        [Test]
+        public void AcceptsHumanoidPB_OnInnerBones_WithPBBlocker()
+        {
+            var prefab = CreatePrefab("DuplicatePBStripping_HumanoidInner_PBBlocker.prefab");
+
+            AssertInnerBones(prefab);
+        }
+
+        private static void AssertInnerBones(GameObject prefab)
+        {
+            var errors = ErrorReport.CaptureErrors(() => AvatarProcessor.ProcessAvatar(prefab));
+            Assert.AreEqual(0, errors.Count);
+
+            var hips = prefab.transform.Find("Armature/Hips");
+            Transform subHips = null;
+            foreach (Transform t in hips)
+            {
+                if (t.gameObject.name.StartsWith("Hips"))
+                {
+                    subHips = t;
+                    break;
+                }
+            }
+
+            Assert.NotNull(subHips);
+            Assert.AreEqual(1, subHips.childCount);
+            Assert.IsTrue(subHips.GetChild(0).name.StartsWith("New Child$"));
+            Assert.IsTrue(subHips.TryGetComponent<VRCPhysBone>(out _));
         }
     }
 }

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner.prefab
@@ -1,0 +1,451 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2498125727964202215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8637901343924930275}
+  m_Layer: 0
+  m_Name: UpperLeg.R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8637901343924930275
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2498125727964202215}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425011545215011340}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5171819189215563704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5460633315343405867}
+  m_Layer: 0
+  m_Name: Spine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5460633315343405867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5171819189215563704}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425011545215011340}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5183706771555486972
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 696974841882562921}
+  m_Layer: 0
+  m_Name: New Child
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &696974841882562921
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5183706771555486972}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425011545215011340}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5761571479978658530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3658090810984334700}
+  - component: {fileID: 8534621584560104554}
+  m_Layer: 0
+  m_Name: ToMerge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3658090810984334700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5761571479978658530}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2425011545215011340}
+  m_Father: {fileID: 6625593713945014388}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8534621584560104554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5761571479978658530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2df373bf91cf30b4bbd495e11cb1a2ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mergeTarget:
+    referencePath: Armature
+    targetObject: {fileID: 6625593713945439624}
+  prefix: 
+  suffix: 
+  legacyLocked: 0
+  LockMode: 2
+  mangleNames: 1
+--- !u!1 &8318249430048328751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2425011545215011340}
+  - component: {fileID: 116145570166396143}
+  m_Layer: 0
+  m_Name: Hips
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2425011545215011340
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8318249430048328751}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5460633315343405867}
+  - {fileID: 3260084934125770558}
+  - {fileID: 8637901343924930275}
+  - {fileID: 696974841882562921}
+  m_Father: {fileID: 3658090810984334700}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &116145570166396143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8318249430048328751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1661641543, guid: 2a2c05204084d904aa4945ccff20d8e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  foldout_transforms: 1
+  foldout_forces: 1
+  foldout_collision: 1
+  foldout_stretchsquish: 1
+  foldout_limits: 1
+  foldout_grabpose: 1
+  foldout_options: 1
+  foldout_gizmos: 0
+  version: 1
+  integrationType: 0
+  rootTransform: {fileID: 0}
+  ignoreTransforms: []
+  endpointPosition: {x: 0, y: 0, z: 0}
+  multiChildType: 0
+  pull: 0.2
+  pullCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spring: 0.2
+  springCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stiffness: 0.2
+  stiffnessCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  gravity: 0
+  gravityCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  gravityFalloff: 0
+  gravityFalloffCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  immobileType: 0
+  immobile: 0
+  immobileCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  allowCollision: 1
+  collisionFilter:
+    allowSelf: 1
+    allowOthers: 1
+  radius: 0
+  radiusCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  colliders: []
+  limitType: 0
+  maxAngleX: 45
+  maxAngleXCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  maxAngleZ: 45
+  maxAngleZCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotation: {x: 0, y: 0, z: 0}
+  limitRotationXCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotationYCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotationZCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  allowGrabbing: 1
+  grabFilter:
+    allowSelf: 1
+    allowOthers: 1
+  allowPosing: 1
+  poseFilter:
+    allowSelf: 1
+    allowOthers: 1
+  snapToHand: 0
+  grabMovement: 0.5
+  maxStretch: 0
+  maxStretchCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  maxSquish: 0
+  maxSquishCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stretchMotion: 0
+  stretchMotionCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  isAnimated: 0
+  resetWhenDisabled: 0
+  parameter: 
+  showGizmos: 1
+  boneOpacity: 0.5
+  limitOpacity: 0.5
+--- !u!1 &8784829580641167551
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3260084934125770558}
+  m_Layer: 0
+  m_Name: UpperLeg.L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3260084934125770558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8784829580641167551}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425011545215011340}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &4779359370445923223
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1846867717766401987, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_Name
+      value: DuplicatePBStripping_HumanoidInner
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3658090810984334700}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fc34bdb40b2180438fb287e87d752cd, type: 3}
+--- !u!4 &6625593713945014388 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+    type: 3}
+  m_PrefabInstance: {fileID: 4779359370445923223}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6625593713945439624 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1846867717766401567, guid: 5fc34bdb40b2180438fb287e87d752cd,
+    type: 3}
+  m_PrefabInstance: {fileID: 4779359370445923223}
+  m_PrefabAsset: {fileID: 0}

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner.prefab.meta
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b64134bbe3efa51449776e476b920317
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_Ignored.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_Ignored.prefab
@@ -1,0 +1,108 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3314855663531197346
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 116145570166396143, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: ignoreTransforms.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 116145570166396143, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: ignoreTransforms.Array.data[0]
+      value: 
+      objectReference: {fileID: 7334299701829505161}
+    - target: {fileID: 116145570166396143, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: ignoreTransforms.Array.data[1]
+      value: 
+      objectReference: {fileID: 233798298552718492}
+    - target: {fileID: 116145570166396143, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: ignoreTransforms.Array.data[2]
+      value: 
+      objectReference: {fileID: 6475971928874796353}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945439316, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_Name
+      value: DuplicatePBStripping_HumanoidInner_Ignored
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b64134bbe3efa51449776e476b920317, type: 3}
+--- !u!4 &233798298552718492 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3260084934125770558, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 3314855663531197346}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6475971928874796353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8637901343924930275, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 3314855663531197346}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &7334299701829505161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5460633315343405867, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 3314855663531197346}
+  m_PrefabAsset: {fileID: 0}

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_Ignored.prefab.meta
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_Ignored.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 52a2875b9b43d1047a7bc3a9d4613edd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_PBBlocker.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_PBBlocker.prefab
@@ -1,0 +1,136 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8692883387518570274
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945014388, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6625593713945439316, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      propertyPath: m_Name
+      value: DuplicatePBStripping_HumanoidInner_PBBlocker
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5171819189215563704, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9202998116771530898}
+    - targetCorrespondingSourceObject: {fileID: 8784829580641167551, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4756456952176026372}
+    - targetCorrespondingSourceObject: {fileID: 2498125727964202215, guid: b64134bbe3efa51449776e476b920317,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2534654980684605449}
+  m_SourcePrefab: {fileID: 100100000, guid: b64134bbe3efa51449776e476b920317, type: 3}
+--- !u!1 &93072112910444445 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8784829580641167551, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 8692883387518570274}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4756456952176026372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 93072112910444445}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5bf908a199a4648845ebe2fd3b5a4bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4568529383833092250 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5171819189215563704, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 8692883387518570274}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9202998116771530898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568529383833092250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5bf908a199a4648845ebe2fd3b5a4bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6487562254561725381 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2498125727964202215, guid: b64134bbe3efa51449776e476b920317,
+    type: 3}
+  m_PrefabInstance: {fileID: 8692883387518570274}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2534654980684605449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6487562254561725381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5bf908a199a4648845ebe2fd3b5a4bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_PBBlocker.prefab.meta
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidInner_PBBlocker.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16772fc19ae8e7b49ab1e94f98420181
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidTip.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidTip.prefab
@@ -1,0 +1,483 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &153081034637439403
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7524471747194580000}
+  - component: {fileID: 8200741828756418565}
+  m_Layer: 0
+  m_Name: ToMerge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7524471747194580000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 153081034637439403}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1962984382521366047}
+  m_Father: {fileID: 1923677775196482311}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8200741828756418565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 153081034637439403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2df373bf91cf30b4bbd495e11cb1a2ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mergeTarget:
+    referencePath: Armature
+    targetObject: {fileID: 1923677775196190459}
+  prefix: 
+  suffix: 
+  legacyLocked: 0
+  LockMode: 2
+  mangleNames: 1
+--- !u!1 &645148391116447186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2027561760184575219}
+  m_Layer: 0
+  m_Name: Child
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2027561760184575219
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645148391116447186}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6717659006790879614}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1399796362742295232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6717659006790879614}
+  - component: {fileID: 2194555605237480662}
+  m_Layer: 0
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6717659006790879614
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399796362742295232}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2027561760184575219}
+  m_Father: {fileID: 3066136301200089550}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2194555605237480662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399796362742295232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1661641543, guid: 2a2c05204084d904aa4945ccff20d8e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  foldout_transforms: 1
+  foldout_forces: 1
+  foldout_collision: 1
+  foldout_stretchsquish: 1
+  foldout_limits: 1
+  foldout_grabpose: 1
+  foldout_options: 1
+  foldout_gizmos: 0
+  version: 1
+  integrationType: 0
+  rootTransform: {fileID: 0}
+  ignoreTransforms: []
+  endpointPosition: {x: 0, y: 0, z: 0}
+  multiChildType: 0
+  pull: 0.2
+  pullCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spring: 0.2
+  springCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stiffness: 0.2
+  stiffnessCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  gravity: 0
+  gravityCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  gravityFalloff: 0
+  gravityFalloffCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  immobileType: 0
+  immobile: 0
+  immobileCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  allowCollision: 1
+  collisionFilter:
+    allowSelf: 1
+    allowOthers: 1
+  radius: 0
+  radiusCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  colliders: []
+  limitType: 0
+  maxAngleX: 45
+  maxAngleXCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  maxAngleZ: 45
+  maxAngleZCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotation: {x: 0, y: 0, z: 0}
+  limitRotationXCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotationYCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  limitRotationZCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  allowGrabbing: 1
+  grabFilter:
+    allowSelf: 1
+    allowOthers: 1
+  allowPosing: 1
+  poseFilter:
+    allowSelf: 1
+    allowOthers: 1
+  snapToHand: 0
+  grabMovement: 0.5
+  maxStretch: 0
+  maxStretchCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  maxSquish: 0
+  maxSquishCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stretchMotion: 0
+  stretchMotionCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  isAnimated: 0
+  resetWhenDisabled: 0
+  parameter: 
+  showGizmos: 1
+  boneOpacity: 0.5
+  limitOpacity: 0.5
+--- !u!1 &4263254571135048414
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8819743074213097153}
+  m_Layer: 0
+  m_Name: Chest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8819743074213097153
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4263254571135048414}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3066136301200089550}
+  m_Father: {fileID: 7352385770120952471}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4581483200136452596
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3066136301200089550}
+  m_Layer: 0
+  m_Name: Neck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3066136301200089550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581483200136452596}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6717659006790879614}
+  m_Father: {fileID: 8819743074213097153}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7424539437707308133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1962984382521366047}
+  m_Layer: 0
+  m_Name: Hips
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1962984382521366047
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7424539437707308133}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7352385770120952471}
+  m_Father: {fileID: 7524471747194580000}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7957102078560458882
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7352385770120952471}
+  m_Layer: 0
+  m_Name: Spine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7352385770120952471
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7957102078560458882}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8819743074213097153}
+  m_Father: {fileID: 1962984382521366047}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &221559126042065124
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1846867717766401987, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_Name
+      value: DuplicatePBStripping_HumanoidTip
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7524471747194580000}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fc34bdb40b2180438fb287e87d752cd, type: 3}
+--- !u!1 &1923677775196190459 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1846867717766401567, guid: 5fc34bdb40b2180438fb287e87d752cd,
+    type: 3}
+  m_PrefabInstance: {fileID: 221559126042065124}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1923677775196482311 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1846867717766632419, guid: 5fc34bdb40b2180438fb287e87d752cd,
+    type: 3}
+  m_PrefabInstance: {fileID: 221559126042065124}
+  m_PrefabAsset: {fileID: 0}

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidTip.prefab.meta
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_HumanoidTip.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b615cc5447c44314994b575a22200863
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_far.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_far.prefab
@@ -23,12 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 43397333450003214}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5388524103681595368}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &709712915065668132
 GameObject:
@@ -55,14 +56,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 709712915065668132}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.9999927, y: -0.76461804, z: -2.4018843}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8923018049112000952}
   - {fileID: 8346263645556903402}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4446924385526016477
 MonoBehaviour:
@@ -365,13 +367,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3294938996247584563}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.0011}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2300981236930770838}
   m_Father: {fileID: 4839204755409456256}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &356280997442785920
 MonoBehaviour:
@@ -548,12 +551,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4932326906014275043}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1450078349704776806}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5343281448102039389
 GameObject:
@@ -579,13 +583,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5343281448102039389}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6824962001568238675}
   m_Father: {fileID: 8923018049112000952}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8084613166182812076
 MonoBehaviour:
@@ -763,13 +768,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6020944473552814992}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5388524103681595368}
   m_Father: {fileID: 8346263645556903402}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6799239616120235895
 MonoBehaviour:
@@ -785,6 +791,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mergeTarget:
     referencePath: Armature
+    targetObject: {fileID: 0}
   prefix: 
   suffix: 
   legacyLocked: 0
@@ -813,13 +820,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7021121575447504728}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4839204755409456256}
   m_Father: {fileID: 5531473902160065818}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8147540163686070565
 GameObject:
@@ -844,11 +852,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8147540163686070565}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1450078349704776806}
   m_Father: {fileID: 5531473902160065818}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_preserve.prefab
+++ b/UnitTests~/DuplicatePBStripping/DuplicatePBStripping_preserve.prefab
@@ -23,13 +23,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5307695925281184}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2470959523001346680}
   m_Father: {fileID: 3288029844994708450}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1185347276494512093
 GameObject:
@@ -54,15 +55,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1185347276494512093}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8466034055491725982}
   - {fileID: 4920308331760759596}
   - {fileID: 1681599259655281294}
   m_Father: {fileID: 3288029844994708450}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2671187349547250459
 GameObject:
@@ -87,12 +89,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2671187349547250459}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8466034055491725982}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3118168415141652901
 GameObject:
@@ -117,13 +120,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3118168415141652901}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4599847896342424235}
   m_Father: {fileID: 1924794259696430912}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3229473751376893384
 GameObject:
@@ -149,12 +153,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3229473751376893384}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1924794259696430912}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1240230512864768401
 MonoBehaviour:
@@ -168,6 +173,15 @@ MonoBehaviour:
   m_Script: {fileID: 1661641543, guid: 2a2c05204084d904aa4945ccff20d8e5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  foldout_transforms: 1
+  foldout_forces: 1
+  foldout_collision: 1
+  foldout_stretchsquish: 1
+  foldout_limits: 1
+  foldout_grabpose: 1
+  foldout_options: 1
+  foldout_gizmos: 0
+  version: 0
   integrationType: 0
   rootTransform: {fileID: 8466034055491725982}
   ignoreTransforms: []
@@ -217,6 +231,9 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowCollision: 1
+  collisionFilter:
+    allowSelf: 1
+    allowOthers: 1
   radius: 0
   radiusCurve:
     serializedVersion: 2
@@ -260,7 +277,14 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowGrabbing: 1
+  grabFilter:
+    allowSelf: 1
+    allowOthers: 1
   allowPosing: 1
+  poseFilter:
+    allowSelf: 1
+    allowOthers: 1
+  snapToHand: 0
   grabMovement: 0.5
   maxStretch: 0
   maxStretchCurve:
@@ -269,7 +293,22 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  maxSquish: 0
+  maxSquishCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stretchMotion: 0
+  stretchMotionCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   isAnimated: 0
+  resetWhenDisabled: 0
   parameter: 
   showGizmos: 1
   boneOpacity: 0.5
@@ -298,15 +337,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3669416188374771048}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3144974420888563984}
   - {fileID: 1058366299372909130}
   - {fileID: 3585740765715002245}
   m_Father: {fileID: 1346911765870406418}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4555694376538259855
 MonoBehaviour:
@@ -322,9 +362,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mergeTarget:
     referencePath: Armature
+    targetObject: {fileID: 0}
   prefix: 
   suffix: 
-  locked: 0
+  legacyLocked: 0
+  LockMode: 2
+  mangleNames: 1
 --- !u!1 &4762681010693511042
 GameObject:
   m_ObjectHideFlags: 0
@@ -348,12 +391,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4762681010693511042}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2470959523001346680}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5060562373779566306
 GameObject:
@@ -378,12 +422,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5060562373779566306}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1924794259696430912}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5538066357489875403
 GameObject:
@@ -408,13 +453,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5538066357489875403}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9118779566147113326}
   m_Father: {fileID: 2470959523001346680}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7059671866930001398
 GameObject:
@@ -439,12 +485,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7059671866930001398}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3144974420888563984}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7546831960978351324
 GameObject:
@@ -471,14 +518,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7546831960978351324}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.9999927, y: -0.76461804, z: -2.4018843}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1924794259696430912}
   - {fileID: 1346911765870406418}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6689100707227635493
 MonoBehaviour:
@@ -506,6 +554,7 @@ MonoBehaviour:
   unityVersion: 
   portraitCameraPositionOffset: {x: 0, y: 0, z: 0}
   portraitCameraRotationOffset: {x: 0, y: 1, z: 0, w: -0.00000004371139}
+  networkIDs: []
   customExpressions: 0
   expressionsMenu: {fileID: 0}
   expressionParameters: {fileID: 0}
@@ -781,12 +830,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8948347872370946622}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2470959523001346680}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5925503763981397634
 MonoBehaviour:
@@ -800,6 +850,15 @@ MonoBehaviour:
   m_Script: {fileID: 1661641543, guid: 2a2c05204084d904aa4945ccff20d8e5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  foldout_transforms: 1
+  foldout_forces: 1
+  foldout_collision: 1
+  foldout_stretchsquish: 1
+  foldout_limits: 1
+  foldout_grabpose: 1
+  foldout_options: 1
+  foldout_gizmos: 0
+  version: 0
   integrationType: 0
   rootTransform: {fileID: 3585740765715002245}
   ignoreTransforms: []
@@ -849,6 +908,9 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowCollision: 1
+  collisionFilter:
+    allowSelf: 1
+    allowOthers: 1
   radius: 0
   radiusCurve:
     serializedVersion: 2
@@ -892,7 +954,14 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowGrabbing: 1
+  grabFilter:
+    allowSelf: 1
+    allowOthers: 1
   allowPosing: 1
+  poseFilter:
+    allowSelf: 1
+    allowOthers: 1
+  snapToHand: 0
   grabMovement: 0.5
   maxStretch: 0
   maxStretchCurve:
@@ -901,7 +970,22 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  maxSquish: 0
+  maxSquishCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stretchMotion: 0
+  stretchMotionCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   isAnimated: 0
+  resetWhenDisabled: 0
   parameter: 
   showGizmos: 1
   boneOpacity: 0.5
@@ -918,6 +1002,15 @@ MonoBehaviour:
   m_Script: {fileID: 1661641543, guid: 2a2c05204084d904aa4945ccff20d8e5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  foldout_transforms: 1
+  foldout_forces: 1
+  foldout_collision: 1
+  foldout_stretchsquish: 1
+  foldout_limits: 1
+  foldout_grabpose: 1
+  foldout_options: 1
+  foldout_gizmos: 0
+  version: 0
   integrationType: 0
   rootTransform: {fileID: 3144974420888563984}
   ignoreTransforms: []
@@ -967,6 +1060,9 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowCollision: 1
+  collisionFilter:
+    allowSelf: 1
+    allowOthers: 1
   radius: 0
   radiusCurve:
     serializedVersion: 2
@@ -1010,7 +1106,14 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   allowGrabbing: 1
+  grabFilter:
+    allowSelf: 1
+    allowOthers: 1
   allowPosing: 1
+  poseFilter:
+    allowSelf: 1
+    allowOthers: 1
+  snapToHand: 0
   grabMovement: 0.5
   maxStretch: 0
   maxStretchCurve:
@@ -1019,7 +1122,22 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  maxSquish: 0
+  maxSquishCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  stretchMotion: 0
+  stretchMotionCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   isAnimated: 0
+  resetWhenDisabled: 0
   parameter: 
   showGizmos: 1
   boneOpacity: 0.5

--- a/UnitTests~/VisibleHeadAccessoryTest/VHA_shapell.prefab
+++ b/UnitTests~/VisibleHeadAccessoryTest/VHA_shapell.prefab
@@ -694,6 +694,7 @@ MonoBehaviour:
   matchAvatarWriteDefaults: 0
   relativePathRoot:
     referencePath: 
+    targetObject: {fileID: 0}
   layerPriority: 0
 --- !u!95 &5357983429381432312
 Animator:

--- a/UnitTests~/_CommonAssets/ShapellAvatar.prefab
+++ b/UnitTests~/_CommonAssets/ShapellAvatar.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1846867717766498495
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_Name
+      value: ShapellAvatar
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4770093150131899536}
+    - targetCorrespondingSourceObject: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8010872081383782814}
+  m_SourcePrefab: {fileID: 100100000, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
+--- !u!1 &1846867717766401987 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4770093150131899536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,138 +352,15 @@ MonoBehaviour:
   contentType: 0
   assetBundleUnityVersion: 
   fallbackStatus: 0
---- !u!1001 &1846867717766498495
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_Name
-      value: ShapellAvatar Variant
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400220, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1418fcab2d94f9d4982cd714b598900f, type: 3}
---- !u!1 &1846867717766401987 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 100220, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1846867717766631969 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400030, guid: 1418fcab2d94f9d4982cd714b598900f,
     type: 3}
   m_PrefabInstance: {fileID: 1846867717766498495}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632359 stripped
+--- !u!4 &1846867717766632283 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 400152, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632363 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400148, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632355 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400156, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632341 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400170, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632447 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400192, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632431 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400208, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632361 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400150, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632353 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400158, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632339 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400172, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632445 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400194, guid: 1418fcab2d94f9d4982cd714b598900f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1846867717766498495}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632429 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400210, guid: 1418fcab2d94f9d4982cd714b598900f,
+  m_CorrespondingSourceObject: {fileID: 400356, guid: 1418fcab2d94f9d4982cd714b598900f,
     type: 3}
   m_PrefabInstance: {fileID: 1846867717766498495}
   m_PrefabAsset: {fileID: 0}
@@ -418,9 +370,69 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1846867717766498495}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1846867717766632283 stripped
+--- !u!4 &1846867717766632339 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 400356, guid: 1418fcab2d94f9d4982cd714b598900f,
+  m_CorrespondingSourceObject: {fileID: 400172, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632341 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400170, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400158, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632355 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400156, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632359 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400152, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632361 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400150, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632363 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400148, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632429 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400210, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632431 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400208, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632445 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400194, guid: 1418fcab2d94f9d4982cd714b598900f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1846867717766498495}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1846867717766632447 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400192, guid: 1418fcab2d94f9d4982cd714b598900f,
     type: 3}
   m_PrefabInstance: {fileID: 1846867717766498495}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
This change adds support for merging humanoid bones that are a target of PhysBones, provided that all humanoid children are excluded from that PhysBone (either with a direct ignores field, or using PB Blocker).

Note: Because this is a significant expansion of support, this will need to wait for a minor release to maintain semver semantics.

Closes: #1406
