### PR TITLE
fix: Use `localOnly` instead of `syncType = NotSynced` when importing parameter asset

### DIFF
--- a/Editor/Inspector/Parameters/AvatarParametersEditor.cs
+++ b/Editor/Inspector/Parameters/AvatarParametersEditor.cs
@@ -211,18 +211,14 @@ namespace nadena.dev.modular_avatar.core.editor
                         default: pst = ParameterSyncType.Float; break;
                     }
 
-                    if (!parameter.networkSynced)
-                    {
-                        pst = ParameterSyncType.NotSynced;
-                    }
-                    
                     target.parameters.Add(new ParameterConfig()
                     {
                         internalParameter = false,
                         nameOrPrefix = parameter.name,
                         isPrefix = false,
                         remapTo = "",
-                        syncType = pst, 
+                        syncType = pst,
+                        localOnly = !parameter.networkSynced,
                         defaultValue = parameter.defaultValue,
                         saved = parameter.saved,
                     });


### PR DESCRIPTION
Reference:

https://github.com/bdunderscore/modular-avatar/blob/242a108703545917eee6b0fd3fe0b57b42c7400a/Runtime/ModularAvatarParameters.cs#L45-L57