### PR TITLE
fix: incorrect first layer weights in Merge Animator

### DIFF
--- a/Editor/MergeAnimatorProcessor.cs
+++ b/Editor/MergeAnimatorProcessor.cs
@@ -121,6 +121,10 @@ namespace nadena.dev.modular_avatar.core.editor
                 basePath = "";
             }
 
+            var firstLayer = clonedController.Layers.FirstOrDefault();
+            // the first layer in an animator controller always has weight 1.0f (regardless of what is serialized)
+            if (firstLayer != null) firstLayer.DefaultWeight = 1.0f;
+
             foreach (var l in clonedController.Layers)
             {
                 if (initialWriteDefaults != null)


### PR DESCRIPTION
Unity ignores the weight of the first layer in a controller, and forces it to one; here, we replicate that behavior in Merge Animator.

Note that we choose to do this here rather than in NDMF - this is because NDMF-level APIs are trying to accurately represent the data in the animator, and should be able to round-trip even "garbage" data there.

Closes: https://github.com/bdunderscore/ndmf/issues/534
Closes: #1472
