### PR TITLE
fix: unity editor shortcuts break while editing MA Parameters text fields

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#1492] 前回のプレリリースでアイコンとロゴアセットが間違っていた問題を修正
+- [#1501] MA Parametersコンポーネントのテキスト入力欄を編集する際にUnityのキーボードショートカットが機能しない問題を修正
 
 ### Changed
 - [#1483] Merge Animator の 「アバターの Write Defaults 設定に合わせる」設定では、Additiveなレイヤー、および単一Stateかつ遷移のないレイヤー

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1492] Fixed incorrect icon and logo assets in prior prerelease
 - [#1489] Fixed compatibility issues between `Merge Blend Tree` or reactive components and MMD worlds.
   See [documentation](https://modular-avatar.nadena.dev/docs/general-behavior/mmd) for details on the new handling.
+- [#1501] Unity keyboard shortcuts don't work when editing text fields on the MA Parameters component
 
 ### Changed
 - [#1483] The Merge Animator "Match Avatar Write Defaults" option will no longer adjust write defaults on states in

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -18,6 +18,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 - [#1460] パラメーターアセットをMA Parametersにインポートするとき、ローカルのみのパラメーターが間違ってアニメーターのみ扱いになる問題を修正
 - [#1489] `Merge Blend Tree` やリアクティブコンポーネントとMMDワールドの互換性の問題を修正。
   詳細は[ドキュメント](https://modular-avatar.nadena.dev/docs/general-behavior/mmd)を参照してください。
+- [#1501] MA Parametersコンポーネントのテキスト入力欄を編集する際にUnityのキーボードショートカットが機能しない問題を修正
 
 ### Changed
 - [#1476] ModularAvatarMergeAnimator と ModularAvatarMergeParameter を新しい NDMF API (`IVirtualizeMotion` と `IVirtualizeAnimatorController`) を使用するように変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "animator only"
 - [#1489] Fixed compatibility issues between `Merge Blend Tree` or reactive components and MMD worlds.
   See [documentation](https://modular-avatar.nadena.dev/docs/general-behavior/mmd) for details on the new handling. 
+- [#1501] Unity keyboard shortcuts don't work when editing text fields on the MA Parameters component 
 
 ### Changed
 - [#1476] Switch ModularAvatarMergeAnimator and ModularAvatarMergeParameter to use new NDMF APIs (`IVirtualizeMotion` and `IVirtualizeAnimatorController`)

--- a/Editor/Inspector/Parameters/AvatarParametersEditor.cs
+++ b/Editor/Inspector/Parameters/AvatarParametersEditor.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.UIElements;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using static nadena.dev.modular_avatar.core.editor.Localization;
@@ -42,7 +41,7 @@ namespace nadena.dev.modular_avatar.core.editor
             listView.selectionType = SelectionType.Multiple;
             listView.RegisterCallback<KeyDownEvent>(evt =>
             {
-                if (evt.keyCode == KeyCode.Delete)
+                if (evt.keyCode == KeyCode.Delete && evt.modifiers == EventModifiers.FunctionKey)
                 {
                     serializedObject.Update();
                     
@@ -66,9 +65,9 @@ namespace nadena.dev.modular_avatar.core.editor
                             listView.SetSelectionWithoutNotify(indices);
                         };
                     }
+
+                    evt.StopPropagation();
                 }
-                
-                evt.StopPropagation();
             }, TrickleDown.NoTrickleDown);
             
             unregisteredListView = root.Q<ListView>("UnregisteredParameters");

--- a/Editor/Inspector/Parameters/ParameterConfigDrawer.cs
+++ b/Editor/Inspector/Parameters/ParameterConfigDrawer.cs
@@ -2,6 +2,7 @@
 
 using System;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 using Toggle = UnityEngine.UIElements.Toggle;
 
@@ -83,8 +84,12 @@ namespace nadena.dev.modular_avatar.core.editor.Parameters
 
             foreach (var elem in root.Query<TextElement>().Build())
             {
-                // Prevent keypresses from bubbling up
-                elem.RegisterCallback<KeyDownEvent>(evt => evt.StopPropagation(), TrickleDown.NoTrickleDown);
+                // Prevent delete keypresses from bubbling up if we're in a text field
+                elem.RegisterCallback<KeyDownEvent>(evt =>
+                {
+                    if (evt.keyCode == KeyCode.Delete && evt.modifiers == EventModifiers.FunctionKey)
+                        evt.StopPropagation();
+                });
             }
 
             return root;


### PR DESCRIPTION
Closes: #1414
