### PR TITLE
fix: typo japanese mmd.md 

### DIFF
--- a/docs~/i18n/ja/docusaurus-plugin-content-docs/current/general-behavior/mmd.md
+++ b/docs~/i18n/ja/docusaurus-plugin-content-docs/current/general-behavior/mmd.md
@@ -11,7 +11,7 @@ Merge Animatorなどで追加されたレイヤーは、（置換モードでも
 `MA MMD Layer Control` という_ステートマシンビヘイビア_を制御したいレイヤーに追加することができます。
 
 また、全体的にこの対応を無効にする場合は、[VRChat Settings](../reference/vrchat-settings)コンポーネントをアバターにつけて、
-該当設置絵を無効にしてください。
+該当設定を無効にしてください。
 
 :::warning
 


### PR DESCRIPTION
It's a simple typo fix.

> You can also disable this behavior entirely by attaching the [VRChat Settings](https://modular-avatar.nadena.dev/docs/reference/vrchat-settings) component to your avatar and **disabling the relevant setting.**
