### PR TITLE
fix: blendshape sync is not applied to the initial state of the avatar on build

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#1632] `Blendshape Sync` が無効化されたオブジェクト上でエディターで動作しない問題を修正
+- [#1633] `Blendshape Sync` がビルド時にアバターの初期状態に正しく適用されない問題を修正
 
 ### Changed
 - [#1608] [#1610] Shape Changerが、アニメーションされても完全に消す仕様になりました

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1629] Report a nonfatal error when an animator being merged has a broken layer (missing state machine)
 
 ### Fixed
-- [#1632] BlendshapeSync would not work in the editor when on a disabled object
+- [#1632] `Blendshape Sync` would not work in the editor when on a disabled object
+- [#1633] `Blendshape Sync` would not be properly applied to the initial state of the avatar on build
 
 ### Changed
 - [#1608] [#1610] Shape Changer will now delete shapekeys fully, even if animated

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -21,6 +21,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 - [#1589] Merge AnimatorやMerge Motionコンポーネントのターゲットがnullの場合に `KeyNotFoundException` が発生する問題を修正
 - [#1605] 複数の Material Setter が競合したときのプレビューがビルド結果と異なる問題を修正
 - [#1632] `Blendshape Sync` が無効化されたオブジェクト上でエディターで動作しない問題を修正
+- [#1633] `Blendshape Sync` がビルド時にアバターの初期状態に正しく適用されない問題を修正
 
 ### Changed
 - [#1608] [#1610] Shape Changerが、アニメーションされても完全に消す仕様になりました

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1587] The Mesh Settings gizmo was not shown when in `SetOrInherit` mode
 - [#1589] A `KeyNotFoundException` could occur when the target of a Merge Animator or Merge Motion component was null
 - [#1605] Fixed an issue where the preview differed from the build result when multiple Material Setters conflicted
-- [#1632] BlendshapeSync would not work in the editor when on a disabled object
+- [#1632] `Blendshape Sync` would not work in the editor when on a disabled object
+- [#1633] `Blendshape Sync` would not be properly applied to the initial state of the avatar on build
 
 ### Changed
 - [#1608] [#1610] Shape Changer will now delete shapekeys fully, even if animated

--- a/UnitTests~/BlendshapeSyncTests/BlendshapeSyncIntegrationTest.cs
+++ b/UnitTests~/BlendshapeSyncTests/BlendshapeSyncIntegrationTest.cs
@@ -39,6 +39,42 @@ namespace modular_avatar_tests
 
             Assert.AreEqual(bindings.Count, 7);
         }
+
+        [Test]
+        public void BlendshapeSync_CopiesValueToDownstreamMeshes()
+        {
+            var root = CreatePrefab("BlendshapeSyncIntegrationTest.prefab");
+
+            // Set a value on BaseMesh's shape_0 and shape_1
+            var baseMesh = root.transform.Find("BaseMesh").GetComponent<UnityEngine.SkinnedMeshRenderer>();
+            var syncedMesh = root.transform.Find("SyncedMesh").GetComponent<UnityEngine.SkinnedMeshRenderer>();
+            int shape0 = baseMesh.sharedMesh.GetBlendShapeIndex("shape_0");
+            int shape1 = baseMesh.sharedMesh.GetBlendShapeIndex("shape_1");
+            
+            // If there's an animator controller on the root animator, it'll apply the initial values in that animation,
+            // which breaks this test. So clear it here.
+            var animator = root.GetComponent<UnityEngine.Animator>();
+            animator.runtimeAnimatorController = null;
+            
+            // Set test values
+            baseMesh.SetBlendShapeWeight(shape0, 42.5f);
+            baseMesh.SetBlendShapeWeight(shape1, 13.7f);
+
+            // Process the avatar (should sync values)
+            AvatarProcessor.ProcessAvatar(root);
+            
+            // Assert that base mesh blendshape weights are unchanged
+            Assert.AreEqual(42.5f, baseMesh.GetBlendShapeWeight(shape0));
+            Assert.AreEqual(13.7f, baseMesh.GetBlendShapeWeight(shape1));
+
+            // By default, the prefab syncs:
+            //   BaseMesh.shape_0 -> SyncedMesh.shape_0_local
+            //   BaseMesh.shape_1 -> SyncedMesh.shape_1
+            int syncedShape0Local = syncedMesh.sharedMesh.GetBlendShapeIndex("shape_0_local");
+            int syncedShape1 = syncedMesh.sharedMesh.GetBlendShapeIndex("shape_1");
+            Assert.AreEqual(42.5f, syncedMesh.GetBlendShapeWeight(syncedShape0Local));
+            Assert.AreEqual(13.7f, syncedMesh.GetBlendShapeWeight(syncedShape1));
+        }
     }
 }
 


### PR DESCRIPTION
Closes: #1598
