### PR TITLE
fix: Equality comparison of material referenced by MaterialSwap

### DIFF
--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
@@ -359,7 +359,7 @@ namespace nadena.dev.modular_avatar.core.editor
                             var originalMaterial = ObjectRegistry.GetReference(m)?.Object as Material ?? m;
                             return (renderer: r, index: i, material: originalMaterial);
                         }))
-                        .Where(x => x.material == (obj.From ? obj.From : null)))
+                        .Where(x => x.material == (obj.From ? ObjectRegistry.GetReference(obj.From)?.Object as Material ?? obj.From : null)))
                     {
                         RegisterAction(swap, renderer, index, obj.To);
                     }


### PR DESCRIPTION
Material Swapにおけるマテリアルの等価性の比較を修正します。

現在のコードではRendererから取得したマテリアルはObjectRegistryからオリジナルを取得しているのに対し、比較するMaterialSwapのsrcにあたるマテリアルはそのまま使用しています。
そのため、Rendererと同じマテリアルではあるものの、編集済みのものがMaterialSwapに割り当てられていた際、片方のみオリジナルを取得した結果、等価比較でfalseを返しています。
この状況はビルド時のMaterialSwap生成や、前のパスの編集等で発生し得るものです。

双方のマテリアルに対しObjectRegistryを用い、オリジナルのマテリアル同士で比較することでこのケースに対応します。