### PR TITLE
fix: VRChat crashes in certain worlds when using Shape Changer Delete modes

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1671] 一部のワールドにおいて、Shape ChangerがVRChatのクラッシュを引き起こす可能性がある問題を修正
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1671] Shape changer could cause VRChat crashes in certain worlds
 
 ### Changed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -11,6 +11,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 ### Added
 
 ### Fixed
+- [#1671] 一部のワールドにおいて、Shape ChangerがVRChatのクラッシュを引き起こす可能性がある問題を修正
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1671] Shape changer could cause VRChat crashes in certain worlds
 
 ### Changed
 

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
@@ -208,34 +208,37 @@ namespace nadena.dev.modular_avatar.core.editor
                     var currentValue = renderer.GetBlendShapeWeight(shapeId);
                     var value = shape.ChangeType == ShapeChangeType.Delete ? 100 : shape.Value;
 
-                    RegisterAction(key, currentValue, value, changer);
-
-                    if (_blendshapeSyncMappings.TryGetValue((renderer, shape.ShapeName), out var bindings))
+                    if (shape.ChangeType == ShapeChangeType.Set)
                     {
-                        // Propagate the new value through any Blendshape Syncs we might have.
-                        // Note that we don't propagate deletes; it's common to e.g. want to delete breasts from the
-                        // base model while retaining outerwear that matches the breast size.
-                        foreach (var binding in bindings)
+                        RegisterAction(key, currentValue, value, changer);
+
+                        if (_blendshapeSyncMappings.TryGetValue((renderer, shape.ShapeName), out var bindings))
                         {
-                            var bindingKey = new TargetProp
+                            // Propagate the new value through any Blendshape Syncs we might have.
+                            // Note that we don't propagate deletes; it's common to e.g. want to delete breasts from the
+                            // base model while retaining outerwear that matches the breast size.
+                            foreach (var binding in bindings)
                             {
-                                TargetObject = binding.Item1,
-                                PropertyName = BlendshapePrefix + binding.Item2
-                            };
-                            var bindingRenderer = binding.Item1;
+                                var bindingKey = new TargetProp
+                                {
+                                    TargetObject = binding.Item1,
+                                    PropertyName = BlendshapePrefix + binding.Item2
+                                };
+                                var bindingRenderer = binding.Item1;
 
-                            var bindingMesh = bindingRenderer.sharedMesh;
-                            if (bindingMesh == null) continue;
+                                var bindingMesh = bindingRenderer.sharedMesh;
+                                if (bindingMesh == null) continue;
 
-                            var bindingShapeIndex = bindingMesh.GetBlendShapeIndex(binding.Item2);
-                            if (bindingShapeIndex < 0) continue;
+                                var bindingShapeIndex = bindingMesh.GetBlendShapeIndex(binding.Item2);
+                                if (bindingShapeIndex < 0) continue;
 
-                            var bindingInitialState = bindingRenderer.GetBlendShapeWeight(bindingShapeIndex);
+                                var bindingInitialState = bindingRenderer.GetBlendShapeWeight(bindingShapeIndex);
 
-                            RegisterAction(bindingKey, bindingInitialState, value, changer);
+                                RegisterAction(bindingKey, bindingInitialState, value, changer);
+                            }
                         }
                     }
-                    
+
                     key = new TargetProp
                     {
                         TargetObject = renderer,

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
@@ -208,37 +208,34 @@ namespace nadena.dev.modular_avatar.core.editor
                     var currentValue = renderer.GetBlendShapeWeight(shapeId);
                     var value = shape.ChangeType == ShapeChangeType.Delete ? 100 : shape.Value;
 
-                    if (shape.ChangeType != ShapeChangeType.Delete)
+                    RegisterAction(key, currentValue, value, changer);
+
+                    if (_blendshapeSyncMappings.TryGetValue((renderer, shape.ShapeName), out var bindings))
                     {
-                        RegisterAction(key, currentValue, value, changer);
-
-                        if (_blendshapeSyncMappings.TryGetValue((renderer, shape.ShapeName), out var bindings))
+                        // Propagate the new value through any Blendshape Syncs we might have.
+                        // Note that we don't propagate deletes; it's common to e.g. want to delete breasts from the
+                        // base model while retaining outerwear that matches the breast size.
+                        foreach (var binding in bindings)
                         {
-                            // Propagate the new value through any Blendshape Syncs we might have.
-                            // Note that we don't propagate deletes; it's common to e.g. want to delete breasts from the
-                            // base model while retaining outerwear that matches the breast size.
-                            foreach (var binding in bindings)
+                            var bindingKey = new TargetProp
                             {
-                                var bindingKey = new TargetProp
-                                {
-                                    TargetObject = binding.Item1,
-                                    PropertyName = BlendshapePrefix + binding.Item2
-                                };
-                                var bindingRenderer = binding.Item1;
+                                TargetObject = binding.Item1,
+                                PropertyName = BlendshapePrefix + binding.Item2
+                            };
+                            var bindingRenderer = binding.Item1;
 
-                                var bindingMesh = bindingRenderer.sharedMesh;
-                                if (bindingMesh == null) continue;
+                            var bindingMesh = bindingRenderer.sharedMesh;
+                            if (bindingMesh == null) continue;
 
-                                var bindingShapeIndex = bindingMesh.GetBlendShapeIndex(binding.Item2);
-                                if (bindingShapeIndex < 0) continue;
+                            var bindingShapeIndex = bindingMesh.GetBlendShapeIndex(binding.Item2);
+                            if (bindingShapeIndex < 0) continue;
 
-                                var bindingInitialState = bindingRenderer.GetBlendShapeWeight(bindingShapeIndex);
+                            var bindingInitialState = bindingRenderer.GetBlendShapeWeight(bindingShapeIndex);
 
-                                RegisterAction(bindingKey, bindingInitialState, value, changer);
-                            }
+                            RegisterAction(bindingKey, bindingInitialState, value, changer);
                         }
                     }
-
+                    
                     key = new TargetProp
                     {
                         TargetObject = renderer,

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
@@ -326,10 +326,12 @@ namespace nadena.dev.modular_avatar.core.editor
 
                 if (nanPlan.Count > 0)
                 {
-                    foreach (var kv in nanPlan)
+                    var shapeNameToBones = GenerateNaNimatedBones(renderer, nanPlan);
+
+                    foreach (var kv in shapeNameToBones)
                     {
                         var shapeName = kv.Key;
-                        var newShape = kv.Value;
+                        var bones = kv.Value;
 
                         var deleteTarget = new TargetProp
                         {
@@ -338,8 +340,8 @@ namespace nadena.dev.modular_avatar.core.editor
                         };
                         var animProp = shapes[deleteTarget];
 
-                        var clip_delete = CreateNaNimationClip(renderer, shapeName, newShape, true);
-                        var clip_retain = CreateNaNimationClip(renderer, shapeName, newShape, false);
+                        var clip_delete = CreateNaNimationClip(renderer, shapeName, bones, true);
+                        var clip_retain = CreateNaNimationClip(renderer, shapeName, bones, false);
 
                         foreach (var group in animProp.actionGroups)
                         {
@@ -348,11 +350,6 @@ namespace nadena.dev.modular_avatar.core.editor
                             group.CustomApplyMotion = isDeleted ? clip_delete : clip_retain;
                         }
 
-                        var index = renderer.sharedMesh.GetBlendShapeIndex(newShape);
-                        var initialWeight = animProp.actionGroups.Any(ag => ag.InitiallyActive) ? 1.0f : 0.0f;
-                        renderer.SetBlendShapeWeight(index, initialWeight);
-                        renderer.updateWhenOffscreen = false;
-                        
                         // Since we won't be inserting this into the default states animation, make sure there's a default
                         // motion to fall back on for non-WD setups.
                         animProp.actionGroups.Insert(0, new ReactionRule(deleteTarget, 0.0f)
@@ -364,7 +361,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        private VirtualClip CreateNaNimationClip(SkinnedMeshRenderer renderer, string shapeName, string nanShape,
+        private VirtualClip CreateNaNimationClip(SkinnedMeshRenderer renderer, string shapeName, List<GameObject> bones,
             bool shouldDelete)
         {
             var asc = context.Extension<AnimatorServicesContext>();
@@ -374,26 +371,80 @@ namespace nadena.dev.modular_avatar.core.editor
             var curve = new AnimationCurve();
             curve.AddKey(new Keyframe(0, 0)
             {
-                value = shouldDelete ? 1.0f : 0.0f
+                value = shouldDelete ? float.NaN : 1.0f
             });
 
-            var binding = EditorCurveBinding.FloatCurve(
-                RuntimeUtil.AvatarRootPath(renderer.gameObject),
-                typeof(SkinnedMeshRenderer),
-                ReactiveObjectAnalyzer.BlendshapePrefix + nanShape
-            );
-            clip.SetFloatCurve(binding, curve);
+            foreach (var bone in bones)
+            {
+                var boneName = asc.ObjectPathRemapper
+                    .GetVirtualPathForObject(bone);
 
-            // AABB recalculation will cause a ton of warnings due to invalid vertex coordinates, so disable it
-            // when any NaNimation is present.
-            clip.SetFloatCurve(
-                asc.ObjectPathRemapper.GetVirtualPathForObject(renderer.gameObject),
-                typeof(SkinnedMeshRenderer),
-                "m_UpdateWhenOffscreen",
-                AnimationCurve.Constant(0, 1, 0)
-            );
-            
+                foreach (var dim in new[] { "x", "y", "z" })
+                {
+                    var binding = EditorCurveBinding.FloatCurve(
+                        boneName,
+                        typeof(Transform),
+                        $"m_LocalScale.{dim}"
+                    );
+                    clip.SetFloatCurve(binding, curve);
+                }
+
+                if (shouldDelete)
+                {
+                    // AABB recalculation will cause a ton of warnings due to invalid vertex coordinates, so disable it
+                    // when any NaNimation is active.
+                    clip.SetFloatCurve(
+                        asc.ObjectPathRemapper.GetVirtualPathForObject(renderer.gameObject),
+                        typeof(SkinnedMeshRenderer),
+                        "m_UpdateWhenOffscreen",
+                        AnimationCurve.Constant(0, 1, 0)
+                    );
+                }
+            }
+
             return clip;
+        }
+
+        private Dictionary<string, List<GameObject>> GenerateNaNimatedBones(SkinnedMeshRenderer renderer,
+            Dictionary<string, List<NaNimationFilter.AddedBone>> plan)
+        {
+            List<(NaNimationFilter.AddedBone, string)> createdBones =
+                plan.SelectMany(kv => kv.Value.Select(bone => (bone, kv.Key)))
+                    .OrderBy(b => b.bone.newBoneIndex)
+                    .ToList();
+
+            var maxNewBoneIndex = createdBones[^1].Item1.newBoneIndex;
+            var bonesArray = new Transform[maxNewBoneIndex + 1];
+            var curBonesArray = renderer.bones;
+            Array.Copy(curBonesArray, 0, bonesArray, 0, curBonesArray.Length);
+
+            // Special case for meshes with no bones; we need to create a bone 0 
+            if (curBonesArray.Length == 0)
+            {
+                bonesArray[0] = renderer.transform;
+            }
+
+            foreach (var pair in createdBones)
+            {
+                var bone = pair.Item1;
+                var shape = pair.Item2;
+
+                if (bonesArray[bone.originalBoneIndex] == null) continue;
+                var newBone = new GameObject("NaNimated Bone for " + shape.Replace('/', '_'));
+                var newBoneTransform = newBone.transform;
+                newBoneTransform.SetParent(bonesArray[bone.originalBoneIndex], false);
+                newBoneTransform.localPosition = Vector3.zero;
+                newBoneTransform.localRotation = Quaternion.identity;
+                newBoneTransform.localScale = Vector3.one;
+
+                newBone.AddComponent<ModularAvatarPBBlocker>();
+                bonesArray[bone.newBoneIndex] = newBoneTransform;
+            }
+
+            renderer.bones = bonesArray;
+
+            return plan.ToDictionary(kv => kv.Key,
+                kv => kv.Value.Select(b => bonesArray[b.newBoneIndex].gameObject).ToList());
         }
 
         #endregion

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationFilter.cs
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationFilter.cs
@@ -2,31 +2,31 @@
 using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.ndmf;
+using Unity.Collections;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
     /// <summary>
-    ///     Generates shape keys which effectively hide vertices. This is done by moving the vertices to +Infinity in all
-    ///     directions, thus ensuring the final location will definitely be outside of the bounds of clip space. This then
-    ///     allow us to hide arbitrary polygons in the mesh dynamically.
-    ///
-    ///     This technique was inspired by "NaNimation" (as originally described by
+    ///     Manipulates the bone weights of a mesh to prepare to hide vertices using "NaNimation" (as originally described by
     ///     d4rk in https://github.com/d4rkc0d3r/d4rkAvatarOptimizer?tab=readme-ov-file#nanimation-toggles ).
-    ///     However, NaNimation requires an animation; we can't set a bone scale to NaN in the initial prefab state of
-    ///     the avatar, and thus this doesn't work when Safety settings block animations. Instead, by using a blendshape,
-    ///     we can create a similar effect with better compatibility.
-    ///
-    ///     Note also that Unity does not allow NaN values in blendshapes, hence the use of +Infinity instead.
+    ///     NaNimation works by animating the scale of bones to NaN, in order to cause any primitives including those vertices
+    ///     to be hidden. This allows for arbitrary sections of the mesh to be hidden without needing specific shader support.
+    ///     (Note that we currently only support using blendshapes to select which vertices to hide, but this could be
+    ///     extended in the future).
     /// </summary>
     internal static class NaNimationFilter
     {
-        internal const string BlendShapeNamePrefix = "__modular-avatar_infinimation_";
-        
-        internal static Dictionary<string, string> ComputeNaNPlan(
+        public struct AddedBone
+        {
+            public int originalBoneIndex;
+            public int newBoneIndex;
+        }
+
+        internal static Dictionary<string, List<AddedBone>> ComputeNaNPlan(
             ref Mesh mesh,
-            List<(string, float)> targetShapeNames,
+            List<(string,float)> targetShapeNames,
             int initialBoneCount
         )
         {
@@ -35,38 +35,81 @@ namespace nadena.dev.modular_avatar.core.editor
             if (vertexCount == 0)
             {
                 // Nothing to do...
-                return new Dictionary<string, string>();
+                return new Dictionary<string, List<AddedBone>>();
             }
 
             var originalMesh = mesh;
             mesh = Object.Instantiate(mesh);
             ObjectRegistry.RegisterReplacedObject(originalMesh, mesh);
 
+            /*
+             * Our high level algorithm is as follows:
+             *
+             * For each NaNimated shape, we need one or more new bones, such that we fully cover all primitives in the shape.
+             * ... however mapping to primitives is expensive, so we just map to vertices instead. This might result in
+             * overcoverage (and thus extra bones), but in most cases shrink shapes are closely bound to bones, so it
+             * shouldn't be a large problem, and greatly reduces the complexity of the algorithm.
+             *
+             * Therefore, for each shape we select the bone covering the most vertices, and add it to the NaNimation plan.
+             * If the bone covers all vertices, we can stop; otherwise, we repeat the process until all vertices are covered.
+             *
+             * If multiple shapes cover the same vertex, we can (but are not required to) use the same original bone
+             * for both shapes. In this case, the NaNimated bones will be nested.
+             */
+            
             var deltaPositions = new Vector3[vertexCount];
             var affectedVertices = new HashSet<int>(vertexCount);
+            var firstBoneIndex = new int[vertexCount];
+
+            var origBoneWeights = mesh.GetAllBoneWeights();
+            var origBonesPerVertex = mesh.GetBonesPerVertex();
+
+            var boneWeights =
+                new NativeArray<BoneWeight1>(origBoneWeights.Length == 0 ? vertexCount : origBoneWeights.Length,
+                    Allocator.Temp);
+            var bonesPerVertex = new NativeArray<byte>(vertexCount, Allocator.Temp);
 
             try
             {
-                var nanindex = 0;
+                if (origBoneWeights.Length == 0)
+                {
+                    // Generate new bone weights for a previously non-skinned mesh.
+                    for (var i = 0; i < vertexCount; i++)
+                    {
+                        boneWeights[i] = new BoneWeight1
+                        {
+                            boneIndex = 0,
+                            weight = 1f
+                        };
+                        bonesPerVertex[i] = 1;
+                    }
 
-                Dictionary<string, string> result = new();
-                var newDeltas = new Vector3[vertexCount];
-                var newNormals = new Vector3[vertexCount];
-                var newTangents = new Vector3[vertexCount];
+                    initialBoneCount++;
+                }
+                else
+                {
+                    boneWeights.CopyFrom(origBoneWeights);
+                    bonesPerVertex.CopyFrom(origBonesPerVertex);
+                }
 
+                var runningBoneIndex = 0;
+
+                for (var v = 0; v < vertexCount; v++)
+                {
+                    firstBoneIndex[v] = runningBoneIndex;
+                    runningBoneIndex += bonesPerVertex[v];
+                }
+
+                var nextBoneIndex = initialBoneCount;
+
+                Dictionary<string, List<AddedBone>> result = new();
                 foreach (var (shapeName, threshold) in targetShapeNames)
                 {
-                    var newShapeName = BlendShapeNamePrefix + (nanindex++);
-
                     var sqrThreshold = threshold * threshold;
                     var shape = mesh.GetBlendShapeIndex(shapeName);
                     if (shape < 0) continue; // shape not found
 
                     affectedVertices.Clear();
-
-                    Array.Fill(newDeltas, Vector3.zero);
-                    Array.Fill(newNormals, Vector3.zero);
-                    Array.Fill(newTangents, Vector3.zero);
 
                     var frameCount = mesh.GetBlendShapeFrameCount(shape);
                     var anyAffected = false;
@@ -80,26 +123,108 @@ namespace nadena.dev.modular_avatar.core.editor
                             {
                                 affectedVertices.Add(v);
                                 anyAffected = true;
-                                newDeltas[v] = new Vector3(float.PositiveInfinity, float.PositiveInfinity,
-                                    float.PositiveInfinity);
                             }
                         }
                     }
 
                     if (!anyAffected) continue;
 
-                    var index = mesh.blendShapeCount;
-                    result.Add(shapeName, newShapeName);
-                    mesh.AddBlendShapeFrame(newShapeName, 1.0f, newDeltas, newNormals, newTangents);
-                    mesh.GetBlendShapeFrameVertices(index, 0, newDeltas, newNormals, newTangents);
+                    var shapePlan = ComputeNaNPlanForShape(ref nextBoneIndex, boneWeights, bonesPerVertex,
+                        firstBoneIndex,
+                        affectedVertices);
+
+                    if (shapePlan.Any())
+                    {
+                        result.Add(shapeName, shapePlan);
+                    }
                 }
+
+                var bindposes = mesh.bindposes;
+                Array.Resize(ref bindposes, nextBoneIndex);
+
+                foreach (var addedBone in result.SelectMany(kv => kv.Value).OrderBy(b => b.originalBoneIndex))
+                {
+                    bindposes[addedBone.newBoneIndex] = bindposes[addedBone.originalBoneIndex];
+                }
+
+                mesh.bindposes = bindposes;
+
+                mesh.SetBoneWeights(bonesPerVertex, boneWeights);
 
                 return result;
             }
             finally
             {
-                // TODO - remove dummy finally block after merging the Delete by Mask changes
+                boneWeights.Dispose();
+                bonesPerVertex.Dispose();
             }
+        }
+
+        private static List<AddedBone> ComputeNaNPlanForShape(
+            ref int nextBoneIndex,
+            NativeArray<BoneWeight1> boneWeights,
+            NativeArray<byte> boneCounts,
+            int[] firstBoneIndex,
+            HashSet<int> vertexMask
+        )
+        {
+            var boneToVertexCount = new Dictionary<int, int>();
+            var remainingVertices = new List<int>();
+
+            foreach (var v in vertexMask)
+            {
+                remainingVertices.Add(v);
+                for (var bi = 0; bi < boneCounts[v]; bi++)
+                {
+                    var boneWeight = boneWeights[bi + firstBoneIndex[v]];
+                    if (boneWeight.weight == 0) continue; // we're avoiding actual floating point zero here specifically
+                    if (boneWeight.boneIndex < 0) continue;
+
+                    var count = boneToVertexCount.GetValueOrDefault(boneWeight.boneIndex, 0);
+                    boneToVertexCount[boneWeight.boneIndex] = count + 1;
+                }
+            }
+
+            var sortedBones = boneToVertexCount
+                .OrderByDescending(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .ToList();
+
+            var shapePlan = new List<AddedBone>();
+
+            while (remainingVertices.Count > 0)
+            {
+                var boneToReplace = sortedBones[0];
+                sortedBones.RemoveAt(0);
+
+                var addedBone = new AddedBone
+                {
+                    originalBoneIndex = boneToReplace,
+                    newBoneIndex = nextBoneIndex++
+                };
+                shapePlan.Add(addedBone);
+
+                remainingVertices.RemoveAll(v =>
+                {
+                    for (var bi = 0; bi < boneCounts[v]; bi++)
+                    {
+                        var boneWeight = boneWeights[bi + firstBoneIndex[v]];
+                        if (boneWeight.weight == 0)
+                            continue; // we're avoiding actual floating point zero here specifically
+                        if (boneWeight.boneIndex < 0) continue;
+                        if (boneWeight.boneIndex == boneToReplace)
+                        {
+                            boneWeight.boneIndex = addedBone.newBoneIndex;
+                            boneWeights[bi + firstBoneIndex[v]] = boneWeight;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
+            }
+
+            return shapePlan;
         }
     }
 }

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using nadena.dev.ndmf.animator;
+using UnityEditor;
+using UnityEngine;
+using VRC.Dynamics;
+using VRC.SDK3.Dynamics.Constraint.Components;
+
+#if MA_VRCSDK3_AVATARS
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    /// <summary>
+    /// Configures the initial state of NaNimation bones.
+    ///
+    /// Because we cannot configure the initial scale of a bone to be NaN, we instead use VRCScaleConstraints
+    /// to animate those bones to NaN when user animations are disabled. When user animations are enabled,
+    /// we turn off the constraints, which allows normal NaNimations to take over.
+    /// </summary>
+    internal static class NaNimationInitialStateMunger
+    {
+        public static void ApplyInitialStates(
+            Transform avatarRoot,
+            Dictionary<string, List<GameObject>> nanplan,
+            List<string> initiallyActive,
+            VirtualClip baseStateClip
+        )
+        {
+            var bonesToSetInitially = initiallyActive.SelectMany(s => nanplan[s])
+                .Distinct();
+
+            foreach (var initialBone in bonesToSetInitially)
+            {
+                if (initialBone == null) continue;
+
+                var constraint = initialBone.AddComponent<VRCScaleConstraint>();
+                constraint.Sources.Add(new VRCConstraintSource
+                {
+                    SourceTransform = constraint.transform,
+                    Weight = float.NaN
+                });
+                constraint.GlobalWeight = 1.0f;
+                constraint.Locked = true;
+                constraint.IsActive = true;
+
+                baseStateClip.SetFloatCurve(
+                    EditorCurveBinding.FloatCurve(
+                        RuntimeUtil.AvatarRootPath(constraint.gameObject),
+                        typeof(VRCScaleConstraint),
+                        "IsActive"
+                    ),
+                    // Disable the constraint when animations are active
+                    AnimationCurve.Constant(0, 1, 0.0f)
+                );
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs.meta
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8c863ab5150d4ec2aa246e4cff44da0c
+timeCreated: 1754775979

--- a/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
+++ b/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
@@ -51,7 +51,8 @@ public class ShapeDeletionAnalysis : TestBase
         AssertMeshDeletion(root);
         
         var mesh = root.GetComponentInChildren<SkinnedMeshRenderer>();
-        Assert.AreEqual(100, mesh.GetBlendShapeWeight(mesh.sharedMesh.GetBlendShapeIndex("bottom")));
+        // blendshape is not updated by Deletes
+        Assert.AreEqual(50, mesh.GetBlendShapeWeight(mesh.sharedMesh.GetBlendShapeIndex("bottom")));
     }
 
 


### PR DESCRIPTION
This change reverts #1660, removing the "infinimation" hack which lead to VRChat crashes, and returns to using NaNimation.
To set initial states of bones, we now use VRCScaleConstraints, which are configured to be active only when animations are disabled, to force the initial bone scale to NaN.

Closes: #1668