### PR TITLE
[Rebase] fix: VRChat crashes in certain worlds when using Shape Changer Delete modes 

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1651] `MA Delete Mesh By Mask` を実装
 
 ### Fixed
+- [#1671] 一部のワールドにおいて、Shape ChangerがVRChatのクラッシュを引き起こす可能性がある問題を修正
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1651] Implement `MA Delete Mesh By Mask`
 
 ### Fixed
+- [#1671] Shape changer could cause VRChat crashes in certain worlds
 
 ### Changed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -12,6 +12,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 - [#1651] `MA Delete Mesh By Mask` を実装
 
 ### Fixed
+- [#1671] 一部のワールドにおいて、Shape ChangerがVRChatのクラッシュを引き起こす可能性がある問題を修正
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1651] Implement `MA Delete Mesh By Mask`
 
 ### Fixed
+- [#1671] Shape changer could cause VRChat crashes in certain worlds
 
 ### Changed
 

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectPass.cs
@@ -288,6 +288,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 {
                     // Don't need to animate this anymore...!
                     shapes.Remove(prop);
+                    initialStates.Remove(prop);
 
                     if (prop.PropertyName.StartsWith(ReactiveObjectAnalyzer.DeletedShapePrefix))
                     {
@@ -305,28 +306,25 @@ namespace nadena.dev.modular_avatar.core.editor
                 // Handle NaNimated shapes next
                 var nanPlan = NaNimationFilter.ComputeNaNPlan(ref mesh, toNaNimate);
                 renderer.sharedMesh = mesh;
-
+                
                 if (nanPlan.Count > 0)
                 {
-                    foreach (var kv in nanPlan)
+                    var nanBones = GenerateNaNimatedBones(renderer, nanPlan);
+
+                    foreach (var kv in nanBones)
                     {
                         (var targetProp, var filter) = kv.Key;
-                        var newShape = kv.Value;
-
+                        var bones = kv.Value;
+                        
                         var animProp = shapes[targetProp];
 
-                        var clip_delete = CreateNaNimationClip(renderer, filter.ToString(), newShape, true);
-                        var clip_retain = CreateNaNimationClip(renderer, filter.ToString(), newShape, false);
+                        var clip_delete = CreateNaNimationClip(renderer, filter.ToString(), bones, true);
+                        var clip_retain = CreateNaNimationClip(renderer, filter.ToString(), bones, false);
 
                         foreach (var group in animProp.actionGroups)
                         {
                             group.CustomApplyMotion = clip_delete;
                         }
-
-                        var index = renderer.sharedMesh.GetBlendShapeIndex(newShape);
-                        var initialWeight = animProp.actionGroups.Any(ag => ag.InitiallyActive) ? 1.0f : 0.0f;
-                        renderer.SetBlendShapeWeight(index, initialWeight);
-                        renderer.updateWhenOffscreen = false;
                         
                         // Since we won't be inserting this into the default states animation, make sure there's a default
                         // motion to fall back on for non-WD setups.
@@ -336,60 +334,93 @@ namespace nadena.dev.modular_avatar.core.editor
                         });
                     }
                 }
-
-                var nanimatedProps = nanPlan.Select(x => x.Key.Item1).ToHashSet();
-
-                foreach (var prop in toNaNimate
-                    .Select(x => x.TargetProp)
-                    .Where(x => !nanimatedProps.Contains(x)))
-                {
-                    // Don't need to animate this anymore...!
-                    shapes.Remove(prop);
-
-                    if (prop.PropertyName.StartsWith(ReactiveObjectAnalyzer.DeletedShapePrefix))
-                    {
-                        var shapeName = prop.PropertyName[ReactiveObjectAnalyzer.DeletedShapePrefix.Length..];
-                        var shapeProp = new TargetProp
-                        {
-                            TargetObject = renderer,
-                            PropertyName = ReactiveObjectAnalyzer.BlendshapePrefix + shapeName
-                        };
-                        shapes.Remove(shapeProp);
-                        initialStates.Remove(shapeProp);
-                    }
-                }
             }
         }
-        
-        private VirtualClip CreateNaNimationClip(SkinnedMeshRenderer renderer, string targetName, string nanShape, bool shouldDelete)
+
+        private VirtualClip CreateNaNimationClip(SkinnedMeshRenderer renderer, string shapeName, List<GameObject> bones,
+            bool shouldDelete)
         {
             var asc = context.Extension<AnimatorServicesContext>();
 
-            var clip = VirtualClip.Create($"NaNimation for {targetName} ({(shouldDelete ? "delete" : "retain")})");
+            var clip = VirtualClip.Create($"NaNimation for {shapeName} ({(shouldDelete ? "delete" : "retain")})");
 
             var curve = new AnimationCurve();
             curve.AddKey(new Keyframe(0, 0)
             {
-                value = shouldDelete ? 1.0f : 0.0f
+                value = shouldDelete ? float.NaN : 1.0f
             });
 
-            var binding = EditorCurveBinding.FloatCurve(
-                RuntimeUtil.AvatarRootPath(renderer.gameObject),
-                typeof(SkinnedMeshRenderer),
-                ReactiveObjectAnalyzer.BlendshapePrefix + nanShape
-            );
-            clip.SetFloatCurve(binding, curve);
+            foreach (var bone in bones)
+            {
+                var boneName = asc.ObjectPathRemapper
+                    .GetVirtualPathForObject(bone);
 
-            // AABB recalculation will cause a ton of warnings due to invalid vertex coordinates, so disable it
-            // when any NaNimation is present.
-            clip.SetFloatCurve(
-                asc.ObjectPathRemapper.GetVirtualPathForObject(renderer.gameObject),
-                typeof(SkinnedMeshRenderer),
-                "m_UpdateWhenOffscreen",
-                AnimationCurve.Constant(0, 1, 0)
-            );
-            
+                foreach (var dim in new[] { "x", "y", "z" })
+                {
+                    var binding = EditorCurveBinding.FloatCurve(
+                        boneName,
+                        typeof(Transform),
+                        $"m_LocalScale.{dim}"
+                    );
+                    clip.SetFloatCurve(binding, curve);
+                }
+
+                if (shouldDelete)
+                {
+                    // AABB recalculation will cause a ton of warnings due to invalid vertex coordinates, so disable it
+                    // when any NaNimation is active.
+                    clip.SetFloatCurve(
+                        asc.ObjectPathRemapper.GetVirtualPathForObject(renderer.gameObject),
+                        typeof(SkinnedMeshRenderer),
+                        "m_UpdateWhenOffscreen",
+                        AnimationCurve.Constant(0, 1, 0)
+                    );
+                }
+            }
+
             return clip;
+        }
+
+        private Dictionary<(TargetProp, IVertexFilter), List<GameObject>> GenerateNaNimatedBones(SkinnedMeshRenderer renderer,
+            Dictionary<(TargetProp, IVertexFilter), List<NaNimationFilter.AddedBone>> plan)
+        {
+            List<(NaNimationFilter.AddedBone, (TargetProp, IVertexFilter))> createdBones =
+                plan.SelectMany(kv => kv.Value.Select(bone => (bone, kv.Key)))
+                    .OrderBy(b => b.bone.newBoneIndex)
+                    .ToList();
+
+            var maxNewBoneIndex = createdBones[^1].Item1.newBoneIndex;
+            var bonesArray = new Transform[maxNewBoneIndex + 1];
+            var curBonesArray = renderer.bones;
+            Array.Copy(curBonesArray, 0, bonesArray, 0, curBonesArray.Length);
+
+            // Special case for meshes with no bones; we need to create a bone 0 
+            if (curBonesArray.Length == 0)
+            {
+                bonesArray[0] = renderer.transform;
+            }
+
+            foreach (var pair in createdBones)
+            {
+                var bone = pair.Item1;
+                var shape = pair.Item2;
+
+                if (bonesArray[bone.originalBoneIndex] == null) continue;
+                var newBone = new GameObject(NaNimationFilter.NaNimatedBonePrefix + shape.Item1.ToString().Replace('/', '_'));
+                var newBoneTransform = newBone.transform;
+                newBoneTransform.SetParent(bonesArray[bone.originalBoneIndex], false);
+                newBoneTransform.localPosition = Vector3.zero;
+                newBoneTransform.localRotation = Quaternion.identity;
+                newBoneTransform.localScale = Vector3.one;
+
+                newBone.AddComponent<ModularAvatarPBBlocker>();
+                bonesArray[bone.newBoneIndex] = newBoneTransform;
+            }
+
+            renderer.bones = bonesArray;
+
+            return plan.ToDictionary(kv => kv.Key,
+                kv => kv.Value.Select(b => bonesArray[b.newBoneIndex].gameObject).ToList());
         }
 
         #endregion
@@ -639,11 +670,11 @@ namespace nadena.dev.modular_avatar.core.editor
                     }
                 });
             }
-            else
+            else if (value is float valueFloat)
             {
                 var curve = new AnimationCurve();
-                curve.AddKey(0, (float) value);
-                curve.AddKey(1, (float) value);
+                curve.AddKey(0, (float) valueFloat);
+                curve.AddKey(1, (float) valueFloat);
 
                 var binding = EditorCurveBinding.FloatCurve(path, componentType, key.PropertyName);
                 AnimationUtility.SetEditorCurve(clip, binding, curve);

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationFilter.cs
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationFilter.cs
@@ -9,23 +9,25 @@ using Object = UnityEngine.Object;
 namespace nadena.dev.modular_avatar.core.editor
 {
     /// <summary>
-    ///     Generates shape keys which effectively hide vertices. This is done by moving the vertices to +Infinity in all
-    ///     directions, thus ensuring the final location will definitely be outside of the bounds of clip space. This then
-    ///     allow us to hide arbitrary polygons in the mesh dynamically.
-    ///
-    ///     This technique was inspired by "NaNimation" (as originally described by
+    ///     Manipulates the bone weights of a mesh to prepare to hide vertices using "NaNimation" (as originally described by
     ///     d4rk in https://github.com/d4rkc0d3r/d4rkAvatarOptimizer?tab=readme-ov-file#nanimation-toggles ).
-    ///     However, NaNimation requires an animation; we can't set a bone scale to NaN in the initial prefab state of
-    ///     the avatar, and thus this doesn't work when Safety settings block animations. Instead, by using a blendshape,
-    ///     we can create a similar effect with better compatibility.
-    ///
-    ///     Note also that Unity does not allow NaN values in blendshapes, hence the use of +Infinity instead.
+    ///     NaNimation works by animating the scale of bones to NaN, in order to cause any primitives including those vertices
+    ///     to be hidden. This allows for arbitrary sections of the mesh to be hidden without needing specific shader support.
+    ///     (Note that we currently only support using blendshapes to select which vertices to hide, but this could be
+    ///     extended in the future).
     /// </summary>
     internal static class NaNimationFilter
     {
-        internal const string BlendShapeNamePrefix = "__modular-avatar_infinimation_";
+        // TODO: Move the bone creation logic into here?
+        public const string NaNimatedBonePrefix = "NaNimatedBone for ";
         
-        internal static Dictionary<(TargetProp, IVertexFilter), string> ComputeNaNPlan(
+        public struct AddedBone
+        {
+            public int originalBoneIndex;
+            public int newBoneIndex;
+        }
+
+        internal static Dictionary<(TargetProp, IVertexFilter), List<AddedBone>> ComputeNaNPlan(
             ref Mesh mesh,
             List<(TargetProp, IVertexFilter)> targets
         )
@@ -42,46 +44,174 @@ namespace nadena.dev.modular_avatar.core.editor
             mesh = Object.Instantiate(mesh);
             ObjectRegistry.RegisterReplacedObject(originalMesh, mesh);
 
+            /*
+             * Our high level algorithm is as follows:
+             *
+             * For each NaNimated shape, we need one or more new bones, such that we fully cover all primitives in the shape.
+             * ... however mapping to primitives is expensive, so we just map to vertices instead. This might result in
+             * overcoverage (and thus extra bones), but in most cases shrink shapes are closely bound to bones, so it
+             * shouldn't be a large problem, and greatly reduces the complexity of the algorithm.
+             *
+             * Therefore, for each shape we select the bone covering the most vertices, and add it to the NaNimation plan.
+             * If the bone covers all vertices, we can stop; otherwise, we repeat the process until all vertices are covered.
+             *
+             * If multiple shapes cover the same vertex, we can (but are not required to) use the same original bone
+             * for both shapes. In this case, the NaNimated bones will be nested.
+             */
+            
             var deltaPositions = new Vector3[vertexCount];
             var affectedVertices = new bool[vertexCount];
+            var firstBoneIndex = new int[vertexCount];
 
+            var origBoneWeights = mesh.GetAllBoneWeights();
+            var origBonesPerVertex = mesh.GetBonesPerVertex();
+
+            var boneWeights =
+                new NativeArray<BoneWeight1>(origBoneWeights.Length == 0 ? vertexCount : origBoneWeights.Length,
+                    Allocator.Temp);
+            var bonesPerVertex = new NativeArray<byte>(vertexCount, Allocator.Temp);
+
+            int initialBoneCount = mesh.bindposeCount;
             try
             {
-                var nanindex = 0;
-
-                Dictionary<(TargetProp, IVertexFilter), string> result = new();
-                var newDeltas = new Vector3[vertexCount];
-                var newNormals = new Vector3[vertexCount];
-                var newTangents = new Vector3[vertexCount];
-
-                foreach (var target in targets)
+                if (origBoneWeights.Length == 0)
                 {
-                    var newShapeName = BlendShapeNamePrefix + (nanindex++);
-                    
-                    Array.Fill(affectedVertices, false);
-                    target.Item2.MarkFilteredVertices(mesh, affectedVertices);
-                    
-                    for (var v = 0; v < vertexCount; v++)
+                    // Generate new bone weights for a previously non-skinned mesh.
+                    for (var i = 0; i < vertexCount; i++)
                     {
-                        if (affectedVertices[v])
+                        boneWeights[i] = new BoneWeight1
                         {
-                            newDeltas[v] = new Vector3(float.PositiveInfinity, float.PositiveInfinity,
-                                float.PositiveInfinity);
-                        }
+                            boneIndex = 0,
+                            weight = 1f
+                        };
+                        bonesPerVertex[i] = 1;
                     }
 
-                    var index = mesh.blendShapeCount;
-                    result.Add(target, newShapeName);
-                    mesh.AddBlendShapeFrame(newShapeName, 1.0f, newDeltas, newNormals, newTangents);
-                    mesh.GetBlendShapeFrameVertices(index, 0, newDeltas, newNormals, newTangents);
+                    initialBoneCount++;
                 }
+                else
+                {
+                    boneWeights.CopyFrom(origBoneWeights);
+                    bonesPerVertex.CopyFrom(origBonesPerVertex);
+                }
+
+                var runningBoneIndex = 0;
+
+                for (var v = 0; v < vertexCount; v++)
+                {
+                    firstBoneIndex[v] = runningBoneIndex;
+                    runningBoneIndex += bonesPerVertex[v];
+                }
+
+                var nextBoneIndex = initialBoneCount;
+
+                Dictionary<(TargetProp, IVertexFilter), List<AddedBone>> result = new();
+                foreach (var (prop, filter) in targets)
+                {
+                    Array.Fill(affectedVertices, false);
+                    filter.MarkFilteredVertices(mesh, affectedVertices);
+
+                    if (!affectedVertices.Any(b => b)) continue;
+
+                    var shapePlan = ComputeNaNPlanForShape(ref nextBoneIndex, boneWeights, bonesPerVertex,
+                        firstBoneIndex,
+                        affectedVertices);
+
+                    if (shapePlan.Any())
+                    {
+                        result.Add((prop, filter), shapePlan);
+                    }
+                }
+
+                var bindposes = mesh.bindposes;
+                Array.Resize(ref bindposes, nextBoneIndex);
+
+                foreach (var addedBone in result.SelectMany(kv => kv.Value).OrderBy(b => b.originalBoneIndex))
+                {
+                    bindposes[addedBone.newBoneIndex] = bindposes[addedBone.originalBoneIndex];
+                }
+
+                mesh.bindposes = bindposes;
+
+                mesh.SetBoneWeights(bonesPerVertex, boneWeights);
 
                 return result;
             }
             finally
             {
-                // TODO - remove dummy finally block after merging the Delete by Mask changes
+                boneWeights.Dispose();
+                bonesPerVertex.Dispose();
             }
+        }
+
+        private static List<AddedBone> ComputeNaNPlanForShape(
+            ref int nextBoneIndex,
+            NativeArray<BoneWeight1> boneWeights,
+            NativeArray<byte> boneCounts,
+            int[] firstBoneIndex,
+            bool[] vertexMask
+        )
+        {
+            var boneToVertexCount = new Dictionary<int, int>();
+            var remainingVertices = new List<int>();
+
+            var vertCount = vertexMask.Length;
+            for (int v = 0; v < vertCount; v++)
+            {
+                if (!vertexMask[v]) continue;
+                
+                remainingVertices.Add(v);
+                for (var bi = 0; bi < boneCounts[v]; bi++)
+                {
+                    var boneWeight = boneWeights[bi + firstBoneIndex[v]];
+                    if (boneWeight.weight == 0) continue; // we're avoiding actual floating point zero here specifically
+                    if (boneWeight.boneIndex < 0) continue;
+
+                    var count = boneToVertexCount.GetValueOrDefault(boneWeight.boneIndex, 0);
+                    boneToVertexCount[boneWeight.boneIndex] = count + 1;
+                }
+            }
+
+            var sortedBones = boneToVertexCount
+                .OrderByDescending(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .ToList();
+
+            var shapePlan = new List<AddedBone>();
+
+            while (remainingVertices.Count > 0)
+            {
+                var boneToReplace = sortedBones[0];
+                sortedBones.RemoveAt(0);
+
+                var addedBone = new AddedBone
+                {
+                    originalBoneIndex = boneToReplace,
+                    newBoneIndex = nextBoneIndex++
+                };
+                shapePlan.Add(addedBone);
+
+                remainingVertices.RemoveAll(v =>
+                {
+                    for (var bi = 0; bi < boneCounts[v]; bi++)
+                    {
+                        var boneWeight = boneWeights[bi + firstBoneIndex[v]];
+                        if (boneWeight.weight == 0)
+                            continue; // we're avoiding actual floating point zero here specifically
+                        if (boneWeight.boneIndex < 0) continue;
+                        if (boneWeight.boneIndex == boneToReplace)
+                        {
+                            boneWeight.boneIndex = addedBone.newBoneIndex;
+                            boneWeights[bi + firstBoneIndex[v]] = boneWeight;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
+            }
+
+            return shapePlan;
         }
     }
 }

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using nadena.dev.ndmf.animator;
+using UnityEditor;
+using UnityEngine;
+using VRC.Dynamics;
+using VRC.SDK3.Dynamics.Constraint.Components;
+
+#if MA_VRCSDK3_AVATARS
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    /// <summary>
+    /// Configures the initial state of NaNimation bones.
+    ///
+    /// Because we cannot configure the initial scale of a bone to be NaN, we instead use VRCScaleConstraints
+    /// to animate those bones to NaN when user animations are disabled. When user animations are enabled,
+    /// we turn off the constraints, which allows normal NaNimations to take over.
+    /// </summary>
+    internal static class NaNimationInitialStateMunger
+    {
+        public static void ApplyInitialStates(
+            Transform avatarRoot,
+            IEnumerable<GameObject> initiallyActive,
+            VirtualClip baseStateClip
+        )
+        {
+            foreach (var initialBone in initiallyActive)
+            {
+                if (initialBone == null) continue;
+
+                var constraint = initialBone.AddComponent<VRCScaleConstraint>();
+                constraint.Sources.Add(new VRCConstraintSource
+                {
+                    SourceTransform = constraint.transform,
+                    Weight = float.NaN
+                });
+                constraint.GlobalWeight = 1.0f;
+                constraint.Locked = true;
+                constraint.IsActive = true;
+
+                baseStateClip.SetFloatCurve(
+                    EditorCurveBinding.FloatCurve(
+                        RuntimeUtil.AvatarRootPath(constraint.gameObject),
+                        typeof(VRCScaleConstraint),
+                        "IsActive"
+                    ),
+                    // Disable the constraint when animations are active
+                    AnimationCurve.Constant(0, 1, 0.0f)
+                );
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs.meta
+++ b/Editor/ReactiveObjects/MeshFiltering/NaNimationInitialStateMunger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8c863ab5150d4ec2aa246e4cff44da0c
+timeCreated: 1754775979

--- a/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
+++ b/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
@@ -76,27 +76,9 @@ public class ShapeDeletionAnalysis : TestBase
         
         AvatarProcessor.ProcessAvatar(root);
 
-        var shapeIndex = mesh.sharedMesh.GetBlendShapeIndex(NaNimationFilter.BlendShapeNamePrefix + 0);
-        Assert.AreNotEqual(-1, shapeIndex);
-        
-        var vertices = mesh.sharedMesh.vertices;
-        var deltaPositions = new Vector3[vertices.Length];
-        
-        mesh.sharedMesh.GetBlendShapeFrameVertices(shapeIndex, 0, deltaPositions, null, null);
-        
-        for (int i = 0; i < vertices.Length; i++)
-        {
-            if (vertices[i].z < 0)
-            {
-                Assert.IsTrue(float.IsInfinity(deltaPositions[i].x),
-                    $"Vertex {i} (z={vertices[i].z}) should have infinite delta position");
-            }
-            else if (vertices[i].z > 0)
-            {
-                Assert.AreEqual(0, deltaPositions[i].x,
-                    $"Vertex {i} (z={vertices[i].z}) should have zero delta position");
-            }
-        }
+        var createdBone = root.GetComponentsInChildren<Transform>()
+            .Any(c => c.gameObject.name.StartsWith(NaNimationFilter.NaNimatedBonePrefix));
+        Assert.IsTrue(createdBone);
     }
     
     private static void AssertBuildDeletion(SkinnedMeshRenderer mesh, GameObject root)
@@ -119,7 +101,7 @@ public class ShapeDeletionAnalysis : TestBase
         });
         Assert.IsNotNull(deletedShape);
         var activeGroup = deletedShape.actionGroups.LastOrDefault(ag => ag.InitiallyActive);
-        Assert.That((activeGroup?.Value as VertexFilterByShape)?.Threshold - 0.01f, Is.LessThanOrEqualTo(0.005f));
+        Assert.That(activeGroup?.Value is IVertexFilter);
         return mesh;
     }
     
@@ -135,7 +117,7 @@ public class ShapeDeletionAnalysis : TestBase
         if (deletedShape != null)
         {
             var activeGroup = deletedShape.actionGroups.LastOrDefault(ag => ag.InitiallyActive);
-            Assert.IsFalse(activeGroup?.Value is VertexFilterByShape f && f.Threshold > 0);
+            Assert.IsFalse(activeGroup?.Value is IVertexFilter);
         }
         
     }

--- a/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
+++ b/UnitTests~/ReactiveComponent/ShapeDeletionAnalysis.cs
@@ -49,6 +49,10 @@ public class ShapeDeletionAnalysis : TestBase
 
         AssertPreviewDeletion(root);
         AssertMeshDeletion(root);
+
+        var mesh = root.GetComponentInChildren<SkinnedMeshRenderer>();
+        // blendshape is not updated by Deletes
+        Assert.AreEqual(0, mesh.GetBlendShapeWeight(mesh.sharedMesh.GetBlendShapeIndex("bottom")));
     }
 
 


### PR DESCRIPTION
This change reverts #1660, removing the "infinimation" hack which lead to VRChat crashes, and returns to using NaNimation.
To set initial states of bones, we now use VRCScaleConstraints, which are configured to be active only when animations are disabled, to force the initial bone scale to NaN.

Closes: #1668