### PR TITLE
fix: culling issues with rootbone=head

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1679] `MA Shape Changer` の削除モードで、頭ボーン配下をルートボーンとして設定したメッシュが一人視点で表示されない問題を修正
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1679] Fix issues where meshes with a root bone under the head could be invisible in first person, when affected by
+  a `MA Shape Changer` in delete mode.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -13,6 +13,8 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 
 ### Fixed
 
+- [#1679] `MA Shape Changer` の削除モードで、頭ボーン配下をルートボーンとして設定したメッシュが一人視点で表示されない問題を修正
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1679] Fix issues where meshes with a root bone under the head could be invisible in first person, when affected by
+  a `MA Shape Changer` in delete mode.
+
 ### Changed
 
 ### Removed

--- a/Editor/FixupPasses/FixupHeadChopRootBone.cs
+++ b/Editor/FixupPasses/FixupHeadChopRootBone.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using nadena.dev.ndmf;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+
+#if !MA_VRCSDK3_AVATARS
+#region Fallback stub implementation
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [RunsOnPlatforms(WellKnownPlatforms.VRChatAvatar30)]
+    internal class FixupHeadChopRootBone : Pass<FixupHeadChopRootBone>
+    {
+        protected override void Execute(ndmf.BuildContext context)
+        {
+            // No-op
+        }
+    }
+}
+#endregion
+#else
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    /// <summary>
+    ///     When we perform NaNimations, we disable the "update when offscreen" option on the affected renderer.
+    ///     This has a side effect: If the root bone is a bone underneath the head, then when the head is scaled down to
+    ///     a near-zero size, the bounding box of the renderer is also scaled down to a near-zero size, and is then culled
+    ///     in first-person view.
+    ///     To avoid this, we detect when the root bone is the head (or a child of the head) and, in this case, create a
+    ///     substitute bone with VRCHeadChop to disable this behavior.
+    /// </summary>
+    [RunsOnPlatforms(WellKnownPlatforms.VRChatAvatar30)]
+    internal class FixupHeadChopRootBone : Pass<FixupHeadChopRootBone>
+    {
+        protected override void Execute(ndmf.BuildContext context)
+        {
+            Dictionary<Transform, Transform> substitutes = new();
+
+            if (!context.AvatarRootTransform.TryGetComponent<Animator>(out var animator)) return;
+            if (animator.avatar == null) return;
+
+            var head = animator.GetBoneTransform(HumanBodyBones.Head);
+            if (head == null) return;
+
+            foreach (var renderer in context.AvatarRootTransform.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            {
+                var rootBone = renderer.rootBone;
+                if (rootBone == null) continue;
+                if (rootBone == head || rootBone.IsChildOf(head))
+                {
+                    if (!substitutes.TryGetValue(rootBone, out var substitute))
+                    {
+                        substitute = new GameObject("RootBoneSubstitute").transform;
+                        substitute.SetParent(context.AvatarRootTransform, false);
+                        substitute.localPosition = Vector3.zero;
+                        substitute.localRotation = Quaternion.identity;
+                        substitute.localScale = Vector3.one;
+
+                        substitute.gameObject.AddComponent<ModularAvatarPBBlocker>();
+
+                        var headChop = substitute.gameObject.AddComponent<VRCHeadChop>();
+                        headChop.targetBones = new[]
+                        {
+                            new VRCHeadChop.HeadChopBone
+                            {
+                                applyCondition = VRCHeadChop.HeadChopBone.ApplyCondition.AlwaysApply,
+                                scaleFactor = 1,
+                                transform = substitute
+                            }
+                        };
+
+                        substitutes[rootBone] = substitute;
+                    }
+
+                    renderer.rootBone = substitute;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/Editor/FixupPasses/FixupHeadChopRootBone.cs.meta
+++ b/Editor/FixupPasses/FixupHeadChopRootBone.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7bda8746d9a24545917f3fed904e1e98
+timeCreated: 1755137115

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -80,6 +80,7 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                             .PreviewingWith(new ShapeChangerPreview(), new MeshDeleterPreview(),
                                 new ObjectSwitcherPreview(), new MaterialSetterPreview());
                     });
+                    seq.Run(FixupHeadChopRootBone.Instance);
                     seq.Run(GameObjectDelayDisablePass.Instance);
 
                     // TODO: We currently run this above MergeArmaturePlugin, because Merge Armature might destroy


### PR DESCRIPTION
When we perform NaNimations, we disable the "update when offscreen" option on the affected renderer.
This has a side effect: If the root bone is a bone underneath the head, then when the head is scaled down to
a near-zero size, the bounding box of the renderer is also scaled down to a near-zero size, and is then culled
in first-person view.

To avoid this, we now detect when the root bone is the head (or a child of the head) and, in this case, create a
substitute root bone with VRCHeadChop to disable this behavior.
