### PR TITLE
fix: Incorrect parent for substitute transform.

### DIFF
--- a/Editor/FixupPasses/FixupHeadChopRootBone.cs
+++ b/Editor/FixupPasses/FixupHeadChopRootBone.cs
@@ -51,7 +51,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     if (!substitutes.TryGetValue(rootBone, out var substitute))
                     {
                         substitute = new GameObject("RootBoneSubstitute").transform;
-                        substitute.SetParent(context.AvatarRootTransform, false);
+                        substitute.SetParent(rootBone, false);
                         substitute.localPosition = Vector3.zero;
                         substitute.localRotation = Quaternion.identity;
                         substitute.localScale = Vector3.one;


### PR DESCRIPTION
AvatarRoot に代替が生成されてしまうため、バウンスが埋まりますね .... 

<img width="1791" height="607" alt="image" src="https://github.com/user-attachments/assets/076d7ebe-4152-4e96-98ec-2728897d4873" />


ひとまず、代替となるボーンの子にする形にしてみました。

<img width="1909" height="817" alt="image" src="https://github.com/user-attachments/assets/f623d70b-925c-4dcf-8475-b49f41c444ed" />
