### PR TITLE
fix: animator parameter was not added when a menu item has reactive components only on its children

### DIFF
--- a/Editor/ReactiveObjects/ParameterAssignerPass.cs
+++ b/Editor/ReactiveObjects/ParameterAssignerPass.cs
@@ -200,7 +200,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
 
             var mamiWithRC = _mamiByParam.Where(kvp => kvp.Value.Any(
-                component => component.TryGetComponent<ReactiveComponent>(out _)
+                component => component.GetComponentInChildren<ReactiveComponent>(true)
             )).ToList();
 
             if (mamiWithRC.Count > 0)


### PR DESCRIPTION
Fixes #1718 です