### PR TITLE
Add discord icon to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub issues](https://img.shields.io/github/issues/bdunderscore/modular-avatar)
 [![Crowdin](https://badges.crowdin.net/modular-avatar/localized.svg)](https://crowdin.com/project/modular-avatar)
 ![Github stars](https://img.shields.io/github/stars/bdunderscore/modular-avatar)
-[![Discord](https://img.shields.io/discord/1201675918956056627?style=for-the-badge)](https://discord.gg/dV4cVpewmM)
+[![Discord](https://img.shields.io/discord/1201675918956056627?style=flat&logo=discord)](https://discord.gg/dV4cVpewmM)
 
 <img alt="Logo" src="https://user-images.githubusercontent.com/64174065/204167997-aca87a7d-c0dc-4e00-9140-3a47a7931e54.png" width="50%">
 


### PR DESCRIPTION
I struggled finding the discord for this server so I wanted to add that to the documentation.

Added discord icon using https://shields.io/badges/discord and grabbed the invite link from bd_ server to use it. Also grabbed the server id for the MA server from the server. 