### PR TITLE
feat: CheckOutfitDrop

### DIFF
--- a/Editor/Inspector/CheckOutfitDrop.meta
+++ b/Editor/Inspector/CheckOutfitDrop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dced2d300cb5b5b4bbf0ff5f499d7260
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
@@ -15,11 +15,15 @@ namespace nadena.dev.modular_avatar.core.editor
         static void Init()
         {
             HierarchyPrefabDropHook.OnPrefabAssetDropped += OnPrefabDropped;
+            // Also target prefab instances in scenes. 
+            // This is intended for a prefab instance that was mistakenly placed at the scene root by a previous D&D to be targeted when it is re-dropped.
             HierarchyPrefabDropHook.OnPrefabInstanceDropped += OnPrefabDropped;
         }
 
         private static void OnPrefabDropped(List<GameObject> droppedObjects)
         {
+            if (!CheckOutfitDropPrefs.EnableCheckOutfitDrop) return;
+
             var targets = new List<GameObject>();
             foreach (var droppedObject in droppedObjects)
             {
@@ -28,7 +32,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     continue;
                 }
 
-                if (IsAlreadyProcessed(outfitHips))
+                if (IsSetuppedOutfit(outfitHips))
                 {
                     var seneview = SceneView.lastActiveSceneView;
                     if (seneview != null)
@@ -38,12 +42,12 @@ namespace nadena.dev.modular_avatar.core.editor
                     continue;
                 }
 
-                if (_processedTargets.Contains(avatarHips))
+                if (_processedTargets.Contains(avatarRoot))
                 {
                     continue;
                 }
 
-                targets.Add(droppedObject);
+                targets.Add(avatarRoot);
             }
 
             if (targets.Count > 0)
@@ -57,7 +61,7 @@ namespace nadena.dev.modular_avatar.core.editor
         }
 
         // Do not target "Preset" or prefabs that have already executed setup outfit as much as possible.
-        private static bool IsAlreadyProcessed(GameObject outfitHips)
+        private static bool IsSetuppedOutfit(GameObject outfitHips)
         {
             var outfitArmature = outfitHips.transform.parent;
 

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
@@ -30,7 +30,11 @@ namespace nadena.dev.modular_avatar.core.editor
 
                 if (IsAlreadyProcessed(outfitHips))
                 {
-                    SceneView.lastActiveSceneView.ShowNotification(new GUIContent(Localization.S("check_outfit_drop.preset_cloth")), 2.0f);
+                    var seneview = SceneView.lastActiveSceneView;
+                    if (seneview != null)
+                    {
+                        seneview.ShowNotification(new GUIContent(Localization.S("check_outfit_drop.preset_cloth")), 2.0f);
+                    }
                     continue;
                 }
 

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
@@ -1,0 +1,69 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    internal static class CheckOutfitDrop
+    {
+        private static readonly HashSet<GameObject> _processedTargets = new();
+
+        [InitializeOnLoadMethod]
+        static void Init()
+        {
+            HierarchyPrefabDropHook.OnPrefabAssetDropped += OnPrefabDropped;
+            HierarchyPrefabDropHook.OnPrefabInstanceDropped += OnPrefabDropped;
+        }
+
+        private static void OnPrefabDropped(List<GameObject> droppedObjects)
+        {
+            var targets = new List<GameObject>();
+            foreach (var droppedObject in droppedObjects)
+            {
+                if (!SetupOutfit.ValidateSetupOutfit(droppedObject, out var avatarRoot, out var avatarHips, out var outfitHips))
+                {
+                    continue;
+                }
+
+                if (IsAlreadyProcessed(outfitHips))
+                {
+                    SceneView.lastActiveSceneView.ShowNotification(new GUIContent(Localization.S("check_outfit_drop.preset_cloth")), 2.0f);
+                    continue;
+                }
+
+                if (_processedTargets.Contains(avatarHips))
+                {
+                    continue;
+                }
+
+                targets.Add(droppedObject);
+            }
+
+            if (targets.Count > 0)
+            {
+                foreach (var target in targets)
+                {
+                    _processedTargets.Add(target);
+                }
+                SetupOutfitWindow.AddEntries(targets);
+            }
+        }
+
+        // Do not target "Preset" or prefabs that have already executed setup outfit as much as possible.
+        private static bool IsAlreadyProcessed(GameObject outfitHips)
+        {
+            var outfitArmature = outfitHips.transform.parent;
+
+            var mergeArmature = outfitArmature.GetComponent<ModularAvatarMergeArmature>();
+            if (mergeArmature != null && mergeArmature.mergeTargetObject != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+} 

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs
@@ -42,12 +42,12 @@ namespace nadena.dev.modular_avatar.core.editor
                     continue;
                 }
 
-                if (_processedTargets.Contains(avatarRoot))
+                if (_processedTargets.Contains(droppedObject))
                 {
                     continue;
                 }
 
-                targets.Add(avatarRoot);
+                targets.Add(droppedObject);
             }
 
             if (targets.Count > 0)

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs.meta
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDrop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 351e83df55d32a64393ae1878694e098
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDropPrefs.cs
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDropPrefs.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using nadena.dev.modular_avatar.ui;
+using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [FilePath("ProjectSettings/Packages/nadena.dev.modular_avatar/CheckOutfitDropPrefs.json", FilePathAttribute.Location.ProjectFolder)]
+    public class CheckOutfitDropPrefs : ScriptableSingleton<CheckOutfitDropPrefs>
+    {
+        [SerializeField] private bool enableCheckOutfitDrop = false;
+        public static bool EnableCheckOutfitDrop
+        {
+            get => instance.enableCheckOutfitDrop;
+            set
+            {
+                if (instance.enableCheckOutfitDrop == value) return;
+                instance.enableCheckOutfitDrop = value;
+                instance.Save(true);
+            }
+        }
+
+        [MenuItem(UnityMenuItems.TopMenu_CheckOutfitDrop, true)]
+        static bool ValidateCheckOutfitDrop()
+        {
+            Menu.SetChecked(UnityMenuItems.TopMenu_CheckOutfitDrop, EnableCheckOutfitDrop);
+            return true;
+        }
+
+        [MenuItem(UnityMenuItems.TopMenu_CheckOutfitDrop, false, UnityMenuItems.TopMenu_CheckOutfitDropOrder)]
+        static void ToggleCheckOutfitDrop()
+        {
+            EnableCheckOutfitDrop = !EnableCheckOutfitDrop;
+        }
+    }
+}

--- a/Editor/Inspector/CheckOutfitDrop/CheckOutfitDropPrefs.cs.meta
+++ b/Editor/Inspector/CheckOutfitDrop/CheckOutfitDropPrefs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da87da3776df7ee499eaa54eba92b9e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/CheckOutfitDrop/ConfirmSetupOutfitWindow.cs
+++ b/Editor/Inspector/CheckOutfitDrop/ConfirmSetupOutfitWindow.cs
@@ -1,0 +1,168 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Pool;
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    internal class SetupOutfitWindow : EditorWindow
+    {
+        private static SetupOutfitWindow? _instance;
+        private static readonly List<GameObject> _entries = new();
+
+        private const float MinWidth = 400f;
+        private const float MinHeight = 150f;
+
+        public static void AddEntry(GameObject entry)
+        {
+            if (entry == null) return;
+            _entries.Add(entry);
+            OnAddEntry();
+        }
+
+        public static void AddEntries(List<GameObject> entries)
+        {
+            var validEntries = entries.Where(entry => entry != null);
+            if (validEntries.Count() == 0) return;
+            _entries.AddRange(validEntries);
+            OnAddEntry();
+        }
+
+        private static void OnAddEntry()
+        {
+            if (_instance == null) {
+                _instance = GetWindow<SetupOutfitWindow>(Localization.S("check_outfit_drop_window.title"));
+                _instance.minSize = new Vector2(MinWidth, MinHeight);
+            }
+            _instance.Repaint();
+        }
+
+        public static void RemoveEntry(GameObject entry)
+        {
+            _entries.Remove(entry);
+            OnRemoveEntry();
+        }
+
+        public static void RemoveEntries(List<GameObject> entries)
+        {
+            foreach (var entry in entries)
+            {
+                _entries.RemoveAll(e => e == entry);
+            }
+            OnRemoveEntry();
+        }
+
+        public static void RemoveAllEntriesAndClose()
+        {
+            _entries.Clear();
+            if (_instance != null) _instance.Close();
+        }
+
+        private static void OnRemoveEntry()
+        {
+            if (_instance != null)
+            {
+                if (_entries.Count == 0) {
+                    _instance.Close();
+                }
+                else {
+                    _instance.Repaint();
+                }
+            }
+        }
+
+        void OnEnable()
+        {
+            Localization.OnLangChange += Repaint;
+        }
+
+        void OnDisable()
+        {
+            _entries.Clear();
+            if (_instance == this) _instance = null;
+            Localization.OnLangChange -= Repaint;
+        }
+
+        void OnGUI()
+        {
+            ProcessDestroyedEntries();
+
+            LogoDisplay.DisplayLogo();
+            DrawTitleBox();
+            DrawEnrties();
+            DrawButtons();
+            DrawDisableDescription();
+            Localization.ShowLanguageUI();
+        }
+
+        private void ProcessDestroyedEntries()
+        {
+            using var _ = ListPool<GameObject>.Get(out var toRemove);
+            foreach (var entry in _entries)
+            {
+                if (entry == null) toRemove.Add(entry!);
+            }
+            if (toRemove.Count > 0) RemoveEntries(toRemove);
+        }
+
+        private void DrawTitleBox()
+        {
+            var titleStyle = new GUIStyle(EditorStyles.label)
+            {
+                fontSize = 18,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter
+            };
+
+            EditorGUILayout.LabelField(Localization.S("check_outfit_drop_window.description"), titleStyle, GUILayout.ExpandWidth(true));
+
+            EditorGUILayout.Space(5);
+
+            var lastRect = GUILayoutUtility.GetLastRect();
+            var lineY = lastRect.yMax - 1;
+            var lineRect = new Rect(lastRect.xMin, lineY, lastRect.width, 2);
+            EditorGUI.DrawRect(lineRect, new Color(1f, 1f, 1f, 0.3f));
+        }
+
+        private void DrawEnrties()
+        {
+            foreach (var entry in _entries)
+            {
+                EditorGUILayout.ObjectField(entry, typeof(GameObject), true);
+            }
+        }
+
+        private void DrawButtons()
+        {
+            using var _ = new EditorGUILayout.HorizontalScope();
+            
+            if (GUILayout.Button(Localization.S("check_outfit_drop_window.setup_button"), GUILayout.ExpandWidth(true)))
+            {
+                foreach (var entry in _entries)
+                {
+                    SetupOutfit.SetupOutfitUI(entry);
+                }
+                RemoveAllEntriesAndClose();
+            }
+            
+            if (GUILayout.Button(Localization.S("check_outfit_drop_window.dismiss_button"), GUILayout.Width(position.width * 0.35f - 20)))
+            {
+                RemoveAllEntriesAndClose();
+            }
+            
+        }
+
+        private void DrawDisableDescription()
+        {
+            var descriptionStyle = new GUIStyle(EditorStyles.label)
+            {
+                fontSize = 10,
+                wordWrap = true,
+            };
+            EditorGUILayout.LabelField(Localization.S("check_outfit_drop_window.disable_description"), descriptionStyle);
+        }
+    }
+} 

--- a/Editor/Inspector/CheckOutfitDrop/ConfirmSetupOutfitWindow.cs.meta
+++ b/Editor/Inspector/CheckOutfitDrop/ConfirmSetupOutfitWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0691ab7fa16cc3f4db6c1111b54fe814
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
+++ b/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
@@ -21,13 +21,21 @@ namespace nadena.dev.modular_avatar.core.editor
     
         private static DragAndDropVisualMode OnHierarchyDrop(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects, bool perform)
         {
-            if (CheckOutfitDropPrefs.EnableCheckOutfitDrop && perform)
+            if (perform && (OnPrefabAssetDropped != null || OnPrefabInstanceDropped != null))
             {
                 var droppedObjects = DragAndDrop.objectReferences.OfType<GameObject>();
                 if (droppedObjects.Count() > 0) 
                 {
                     var dropDestinationParent = GetDropDestinationParent(dropTargetInstanceID, dropMode, parentForDraggedObjects);
-                    ProcessDroppedObjects(droppedObjects, dropDestinationParent);
+
+                    if (OnPrefabAssetDropped != null)
+                    {
+                        ProcessPrefabAssets(droppedObjects, dropDestinationParent, OnPrefabAssetDropped);
+                    }
+                    if (OnPrefabInstanceDropped != null)
+                    {
+                        ProcessPrefabInstancesInScene(droppedObjects, OnPrefabInstanceDropped);
+                    }
                 }
             }
             return DragAndDropVisualMode.None; // handler is used for hook only.
@@ -56,20 +64,6 @@ namespace nadena.dev.modular_avatar.core.editor
             }
 
             return dropDestinationParent;
-        }
-
-        private static void ProcessDroppedObjects(IEnumerable<GameObject> droppedObjects, Transform? dropDestinationParent)
-        {
-            if (OnPrefabAssetDropped != null)
-            {
-                ProcessPrefabAssets(droppedObjects, dropDestinationParent, OnPrefabAssetDropped);
-            }
-            // Also target prefab instances in scenes. 
-            // This is intended for a prefab instance that was mistakenly placed at the scene root by a previous D&D to be targeted when it is re-dropped.
-            if (OnPrefabInstanceDropped != null)
-            {
-                ProcessPrefabInstancesInScene(droppedObjects, OnPrefabInstanceDropped);
-            }
         }
 
         private static void ProcessPrefabAssets(IEnumerable<GameObject> droppedObjects, Transform? dropDestinationParent, Action<List<GameObject>> onDropped)

--- a/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
+++ b/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
@@ -1,0 +1,144 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    internal static class HierarchyPrefabDropHook
+    {
+        public static event Action<List<GameObject>>? OnPrefabAssetDropped;
+        public static event Action<List<GameObject>>? OnPrefabInstanceDropped;
+
+        [InitializeOnLoadMethod]
+        static void Init()
+        {
+            DragAndDrop.AddDropHandler(OnHierarchyDrop);
+        }
+    
+        private static DragAndDropVisualMode OnHierarchyDrop(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects, bool perform)
+        {
+            if (CheckOutfitDropPrefs.EnableCheckOutfitDrop && perform)
+            {
+                var droppedObjects = DragAndDrop.objectReferences.OfType<GameObject>();
+                if (droppedObjects.Count() > 0) 
+                {
+                    var dropDestinationParent = GetDropDestinationParent(dropTargetInstanceID, dropMode, parentForDraggedObjects);
+                    ProcessDroppedObjects(droppedObjects, dropDestinationParent);
+                }
+            }
+            return DragAndDropVisualMode.None; // handler is used for hook only.
+        }
+
+        private static Transform? GetDropDestinationParent(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects)
+        {
+            Transform? dropDestinationParent;
+
+            if (parentForDraggedObjects == null)
+            {
+                var dropTarget = EditorUtility.InstanceIDToObject(dropTargetInstanceID) as GameObject;
+                if (dropTarget == null) return null;
+
+                dropDestinationParent = dropMode switch
+                {
+                    HierarchyDropFlags.DropUpon => dropTarget.transform,
+                    HierarchyDropFlags.DropBetween or HierarchyDropFlags.DropAbove => dropTarget.transform.parent,
+                    HierarchyDropFlags.DropAfterParent => dropTarget.transform.parent,
+                    _ => null,
+                };
+            }
+            else // parentForDraggedObjects may be set when in Prefab mode.
+            {
+                dropDestinationParent = parentForDraggedObjects;
+            }
+
+            return dropDestinationParent;
+        }
+
+        private static void ProcessDroppedObjects(IEnumerable<GameObject> droppedObjects, Transform? dropDestinationParent)
+        {
+            if (OnPrefabAssetDropped != null)
+            {
+                ProcessPrefabAssets(droppedObjects, dropDestinationParent, OnPrefabAssetDropped);
+            }
+            // Also target prefab instances in scenes. 
+            // This is intended for a prefab instance that was mistakenly placed at the scene root by a previous D&D to be targeted when it is re-dropped.
+            if (OnPrefabInstanceDropped != null)
+            {
+                ProcessPrefabInstancesInScene(droppedObjects, OnPrefabInstanceDropped);
+            }
+        }
+
+        private static void ProcessPrefabAssets(IEnumerable<GameObject> droppedObjects, Transform? dropDestinationParent, Action<List<GameObject>> onDropped)
+        {
+            var droppedPrefabAssets = droppedObjects
+                .Where(PrefabUtility.IsPartOfPrefabAsset)
+                .ToHashSet();
+            
+            if (droppedPrefabAssets.Count == 0) return;
+
+            // Get instanciaed prefab instances by comparing GameObjects in the scene between frames.
+
+            var beforeSceneGameObjects = CollectSceneGameObjects(dropDestinationParent);
+            // Delay to run after instanciating prefab and parenting a dropped gameobject
+            EditorApplication.delayCall += () =>
+            {
+                var targets = new List<GameObject>();
+
+                var afterSceneGameObjects = CollectSceneGameObjects(dropDestinationParent);
+                afterSceneGameObjects.RemoveWhere(beforeSceneGameObjects.Contains);
+                foreach (var newSceneGameObject in afterSceneGameObjects)
+                {
+                    var parentPrefab = PrefabUtility.GetCorrespondingObjectFromSource(newSceneGameObject);
+                    if (parentPrefab != null && droppedPrefabAssets.Contains(parentPrefab))
+                    {
+                        targets.Add(newSceneGameObject);
+                    }
+                }
+                
+                onDropped.Invoke(targets);
+            };
+
+            // if the destination is null (unknown or the root), all game objects in scenes are searched.
+            // If the destination is known, only the direct children are searched for optimazation.
+            static HashSet<GameObject> CollectSceneGameObjects(Transform? parent)
+            {
+                if (parent != null)
+                {
+                    var directChildren = new HashSet<GameObject>();
+                    foreach (Transform child in parent)
+                    {
+                        directChildren.Add(child.gameObject);
+                    }
+                    return directChildren;
+                }
+                else
+                {
+                    var allGameObjects = UnityEngine.Object.FindObjectsOfType<GameObject>();
+                    return allGameObjects.ToHashSet();
+                }
+            }
+        }
+
+        private static void ProcessPrefabInstancesInScene(IEnumerable<GameObject> droppedObjects, Action<List<GameObject>> onDropped)
+        {
+            // PrefabUtility.IsPartOfPrefabInstance may return true if it is part of an prefab asset.
+            // so use PrefabUtility.IsPartOfNonAssetPrefabInstance instead.
+            var droppedPrefabInstances = droppedObjects
+                .Where(PrefabUtility.IsPartOfNonAssetPrefabInstance)
+                .ToList();
+
+            if (droppedPrefabInstances.Count == 0) return;
+            
+            // Delay to run after parenting a dropped gameobject 
+            EditorApplication.delayCall += () =>
+            {
+                onDropped.Invoke(droppedPrefabInstances);
+            };
+        }
+
+    }
+}

--- a/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
+++ b/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs
@@ -23,14 +23,12 @@ namespace nadena.dev.modular_avatar.core.editor
         {
             if (perform && (OnPrefabAssetDropped != null || OnPrefabInstanceDropped != null))
             {
-                var droppedObjects = DragAndDrop.objectReferences.OfType<GameObject>();
-                if (droppedObjects.Count() > 0) 
+                var droppedObjects = DragAndDrop.objectReferences.OfType<GameObject>().ToList();
+                if (droppedObjects.Count > 0) 
                 {
-                    var dropDestinationParent = GetDropDestinationParent(dropTargetInstanceID, dropMode, parentForDraggedObjects);
-
                     if (OnPrefabAssetDropped != null)
                     {
-                        ProcessPrefabAssets(droppedObjects, dropDestinationParent, OnPrefabAssetDropped);
+                        ProcessPrefabAssets(droppedObjects, OnPrefabAssetDropped);
                     }
                     if (OnPrefabInstanceDropped != null)
                     {
@@ -41,32 +39,7 @@ namespace nadena.dev.modular_avatar.core.editor
             return DragAndDropVisualMode.None; // handler is used for hook only.
         }
 
-        private static Transform? GetDropDestinationParent(int dropTargetInstanceID, HierarchyDropFlags dropMode, Transform parentForDraggedObjects)
-        {
-            Transform? dropDestinationParent;
-
-            if (parentForDraggedObjects == null)
-            {
-                var dropTarget = EditorUtility.InstanceIDToObject(dropTargetInstanceID) as GameObject;
-                if (dropTarget == null) return null;
-
-                dropDestinationParent = dropMode switch
-                {
-                    HierarchyDropFlags.DropUpon => dropTarget.transform,
-                    HierarchyDropFlags.DropBetween or HierarchyDropFlags.DropAbove => dropTarget.transform.parent,
-                    HierarchyDropFlags.DropAfterParent => dropTarget.transform.parent,
-                    _ => null,
-                };
-            }
-            else // parentForDraggedObjects may be set when in Prefab mode.
-            {
-                dropDestinationParent = parentForDraggedObjects;
-            }
-
-            return dropDestinationParent;
-        }
-
-        private static void ProcessPrefabAssets(IEnumerable<GameObject> droppedObjects, Transform? dropDestinationParent, Action<List<GameObject>> onDropped)
+        private static void ProcessPrefabAssets(IEnumerable<GameObject> droppedObjects, Action<List<GameObject>> onDropped)
         {
             var droppedPrefabAssets = droppedObjects
                 .Where(PrefabUtility.IsPartOfPrefabAsset)
@@ -74,47 +47,96 @@ namespace nadena.dev.modular_avatar.core.editor
             
             if (droppedPrefabAssets.Count == 0) return;
 
-            // Get instanciaed prefab instances by comparing GameObjects in the scene between frames.
+            StartWatchingCreatedPrefabInstances(droppedPrefabAssets, onDropped);
+        }
 
-            var beforeSceneGameObjects = CollectSceneGameObjects(dropDestinationParent);
-            // Delay to run after instanciating prefab and parenting a dropped gameobject
-            EditorApplication.delayCall += () =>
+        private static void StartWatchingCreatedPrefabInstances(HashSet<GameObject> droppedPrefabAssets, Action<List<GameObject>> onDropped)
+        {
+            var remainingUpdates = 10;
+            var isSubscribed = false;
+
+            bool StopWatching()
             {
-                var targets = new List<GameObject>();
+                if (!isSubscribed) return false;
 
-                var afterSceneGameObjects = CollectSceneGameObjects(dropDestinationParent);
-                afterSceneGameObjects.RemoveWhere(beforeSceneGameObjects.Contains);
-                foreach (var newSceneGameObject in afterSceneGameObjects)
-                {
-                    var parentPrefab = PrefabUtility.GetCorrespondingObjectFromSource(newSceneGameObject);
-                    if (parentPrefab != null && droppedPrefabAssets.Contains(parentPrefab))
-                    {
-                        targets.Add(newSceneGameObject);
-                    }
-                }
-                
-                onDropped.Invoke(targets);
-            };
+                ObjectChangeEvents.changesPublished -= HandleObjectChangesPublished;
+                EditorApplication.update -= TimeoutWatching;
+                isSubscribed = false;
+                return true;
+            }
 
-            // if the destination is null (unknown or the root), all game objects in scenes are searched.
-            // If the destination is known, only the direct children are searched for optimazation.
-            static HashSet<GameObject> CollectSceneGameObjects(Transform? parent)
+            void TimeoutWatching()
             {
-                if (parent != null)
+                remainingUpdates--;
+                if (remainingUpdates <= 0)
                 {
-                    var directChildren = new HashSet<GameObject>();
-                    foreach (Transform child in parent)
-                    {
-                        directChildren.Add(child.gameObject);
-                    }
-                    return directChildren;
-                }
-                else
-                {
-                    var allGameObjects = UnityEngine.Object.FindObjectsOfType<GameObject>();
-                    return allGameObjects.ToHashSet();
+                    StopWatching();
                 }
             }
+
+            void HandleObjectChangesPublished(ref ObjectChangeEventStream stream)
+            {
+                OnObjectChangesPublished(stream, droppedPrefabAssets, onDropped, StopWatching);
+            }
+
+            ObjectChangeEvents.changesPublished += HandleObjectChangesPublished;
+            EditorApplication.update += TimeoutWatching;
+            isSubscribed = true;
+        }
+
+        private static void OnObjectChangesPublished(
+            ObjectChangeEventStream stream,
+            HashSet<GameObject> droppedPrefabAssets,
+            Action<List<GameObject>> onDropped,
+            Func<bool> stopWatching)
+        {
+            var createdGameObjects = CollectCreatedGameObjects(stream);
+            if (createdGameObjects.Count == 0) return;
+
+            // Delay to run after Unity finishes instantiating and parenting the dropped prefab.
+            EditorApplication.delayCall += () =>
+            {
+                var targets = ResolveDroppedPrefabInstances(createdGameObjects, droppedPrefabAssets);
+                if (targets.Count == 0 || !stopWatching()) return;
+
+                onDropped.Invoke(targets);
+            };
+        }
+
+        private static List<GameObject> CollectCreatedGameObjects(ObjectChangeEventStream stream)
+        {
+            var createdGameObjects = new List<GameObject>();
+
+            for (var i = 0; i < stream.length; i++)
+            {
+                if (stream.GetEventType(i) != ObjectChangeKind.CreateGameObjectHierarchy) continue;
+
+                stream.GetCreateGameObjectHierarchyEvent(i, out var data);
+                if (EditorUtility.InstanceIDToObject(data.instanceId) is not GameObject createdGameObject) continue;
+
+                createdGameObjects.Add(createdGameObject);
+            }
+
+            return createdGameObjects;
+        }
+
+        private static List<GameObject> ResolveDroppedPrefabInstances(IEnumerable<GameObject> createdGameObjects, HashSet<GameObject> droppedPrefabAssets)
+        {
+            var targets = new HashSet<GameObject>();
+
+            foreach (var createdGameObject in createdGameObjects)
+            {
+                var prefabInstanceRoot = PrefabUtility.GetNearestPrefabInstanceRoot(createdGameObject);
+                if (prefabInstanceRoot == null) continue;
+
+                var sourcePrefab = PrefabUtility.GetCorrespondingObjectFromSource(prefabInstanceRoot);
+                if (sourcePrefab != null && droppedPrefabAssets.Contains(sourcePrefab))
+                {
+                    targets.Add(prefabInstanceRoot);
+                }
+            }
+
+            return targets.ToList();
         }
 
         private static void ProcessPrefabInstancesInScene(IEnumerable<GameObject> droppedObjects, Action<List<GameObject>> onDropped)

--- a/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs.meta
+++ b/Editor/Inspector/CheckOutfitDrop/HierarchyPrefabDropHook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b62b3cee3bf91af4f875b923807faf36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -405,5 +405,11 @@
   "validation.global_collider.no_global_colliders_available_vrc:description": "For VRC, you can't use more than 8 Global Colliders. You currently have {0}.",
   "validation.global_collider.no_global_colliders_available_vrc:hint": "Reduce the number of MA Global Collider components.",
   "validation.global_collider.manual_collider_overwrite": "Global Collider components are manually using the same collider.",
-  "validation.global_collider.manual_collider_overwrite:description": "The last such component will overwrite prior components."
+  "validation.global_collider.manual_collider_overwrite:description": "The last such component will overwrite prior components.",
+  "check_outfit_drop.preset_cloth": "An already set up outfit has been placed. Processing will be skipped.",
+  "check_outfit_drop_window.title": "Check Outfit Drop",
+  "check_outfit_drop_window.description": "Setup Outfit?",
+  "check_outfit_drop_window.setup_button": "Setup Outfit",
+  "check_outfit_drop_window.dismiss_button": "Dismiss",
+  "check_outfit_drop_window.disable_description": "You can disable this in Tools/Modular Avatar/Check Outfit Drop."
 }

--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -260,6 +260,7 @@
   "setup_outfit.err.no_animator": "Your avatar does not have an Animator component.",
   "setup_outfit.err.no_hips": "Your avatar does not have a Hips bone. Setup Outfit only works on humanoid avatars.",
   "setup_outfit.err.no_outfit_hips": "Unable to identify the Hips object for the outfit. If you're trying to attach an accessory, use the Bone Proxy component instead. Searched for objects containing the following names(case-insensitive):",
+  "setup_outfit.success": "Setup Outfit completed successfully",
   "move_independently.group-header": "Objects to move together",
   "scale_adjuster.scale": "Scale adjustment",
   "scale_adjuster.adjust_children": "Adjust position of child objects",

--- a/Editor/Localization/ja-JP.json
+++ b/Editor/Localization/ja-JP.json
@@ -401,5 +401,11 @@
   "validation.global_collider.no_global_colliders_available_vrc:description": "VRCでは、Global Collider は8個までしか使用できません。現在は {0} 個使用しています。",
   "validation.global_collider.no_global_colliders_available_vrc:hint": "MA Global Collider コンポーネントの数を減らしてください。",
   "validation.global_collider.manual_collider_overwrite": "複数の Global Collider コンポーネントが同じコライダーを手動で使用しています。",
-  "validation.global_collider.manual_collider_overwrite:description": "最後コンポーネントが一番目を優先されます。"
+  "validation.global_collider.manual_collider_overwrite:description": "最後コンポーネントが一番目を優先されます。",
+  "check_outfit_drop.preset_cloth": "既にセットアップされている衣装が配置されました。処理をスキップします。",
+  "check_outfit_drop_window.title": "Check Outfit Drop",
+  "check_outfit_drop_window.description": "衣装をセットアップしますか？",
+  "check_outfit_drop_window.setup_button": "衣装をセットアップ",
+  "check_outfit_drop_window.dismiss_button": "却下",
+  "check_outfit_drop_window.disable_description": "この機能はTools/Modular Avatar/Check Outfit Dropから無効にできます。"
 }

--- a/Editor/Localization/ja-JP.json
+++ b/Editor/Localization/ja-JP.json
@@ -256,6 +256,7 @@
   "setup_outfit.err.no_animator": "アバターにAnimatorコンポーネントがありません。",
   "setup_outfit.err.no_hips": "アバターにHipsボーンがありません。なお、Setup OutfitはHumanoidアバター以外には対応していません。",
   "setup_outfit.err.no_outfit_hips": "衣装のHipsボーンを発見できませんでした。アクセサリー等に対してSetup Outfitを試みた場合は、代わりにBone Proxyコンポーネントを使って配置してみてください。\n以下の名前を含むボーンを（大文字・小文字を区別つけずに）探しました：",
+  "setup_outfit.success": "衣装のセットアップが正常に完了しました",
   "move_independently.group-header": "同時に動かすオブジェクト",
   "scale_adjuster.scale": "Scale調整値",
   "scale_adjuster.adjust_children": "子オブジェクトの位置を調整",

--- a/Editor/SetupOutfit.cs
+++ b/Editor/SetupOutfit.cs
@@ -136,15 +136,11 @@ namespace nadena.dev.modular_avatar.core.editor
         [PublicAPI]
         public static void SetupOutfitUI(GameObject outfitRoot)
         {
-            if (!ValidateSetupOutfit(outfitRoot))
+            if (!ValidateSetupOutfit(outfitRoot, out var avatarRoot, out var avatarHips, out var outfitHips))
             {
                 ESOErrorWindow.Show(errorHeader, errorMessageGroups);
                 return;
             }
-
-            if (!FindBones(outfitRoot,
-                    out var avatarRoot, out var avatarHips, out var outfitHips)
-               ) return;
 
             Undo.SetCurrentGroupName("Setup Outfit");
 
@@ -465,14 +461,16 @@ namespace nadena.dev.modular_avatar.core.editor
                 errorHeader = S_f("setup_outfit.err.header", obj.name);
                 if (!(obj is GameObject gameObj)) return false;
 
-                if (!ValidateSetupOutfit(gameObj)) return false;
+                if (!ValidateSetupOutfit(gameObj, out _, out _, out _)) return false;
             }
 
             return true;
         }
 
-        private static bool ValidateSetupOutfit(GameObject gameObj)
+        internal static bool ValidateSetupOutfit(GameObject gameObj, out GameObject avatarRoot, out GameObject avatarHips, out GameObject outfitHips)
         {
+            avatarRoot = avatarHips = outfitHips = null;
+
             if (gameObj == null)
             {
                 errorHeader = S("setup_outfit.err.header.notarget");
@@ -483,7 +481,7 @@ namespace nadena.dev.modular_avatar.core.editor
             errorHeader = S_f("setup_outfit.err.header", gameObj.name);
             var xform = gameObj.transform;
 
-            if (!FindBones(gameObj, out var _, out var _, out var outfitHips)) return false;
+            if (!FindBones(gameObj, out avatarRoot, out avatarHips, out outfitHips)) return false;
 
             // Some users have been accidentally running Setup Outfit on the avatar itself, and/or nesting avatar
             // descriptors when transplanting outfits. Block this (and require that there be only one avdesc) by

--- a/Editor/SetupOutfit.cs
+++ b/Editor/SetupOutfit.cs
@@ -275,6 +275,8 @@ namespace nadena.dev.modular_avatar.core.editor
 
                 PrefabUtility.RecordPrefabInstancePropertyModifications(meshSettings);
             }
+
+            SceneView.lastActiveSceneView.ShowNotification(new GUIContent(S("setup_outfit.success")), 2.0f);
         }
 
         internal static Dictionary<Transform, HumanBodyBones> GetOutfitHumanoidBones(Transform outfitRoot, Animator outfitAnimator)

--- a/Editor/SetupOutfit.cs
+++ b/Editor/SetupOutfit.cs
@@ -276,7 +276,11 @@ namespace nadena.dev.modular_avatar.core.editor
                 PrefabUtility.RecordPrefabInstancePropertyModifications(meshSettings);
             }
 
-            SceneView.lastActiveSceneView.ShowNotification(new GUIContent(S("setup_outfit.success")), 2.0f);
+            var seneview = SceneView.lastActiveSceneView;
+            if (seneview != null)
+            {
+                seneview.ShowNotification(new GUIContent(S("setup_outfit.success")), 2.0f);
+            }
         }
 
         internal static Dictionary<Transform, HumanBodyBones> GetOutfitHumanoidBones(Transform outfitRoot, Animator outfitAnimator)

--- a/Runtime/UI/UnityMenuItems.cs
+++ b/Runtime/UI/UnityMenuItems.cs
@@ -37,6 +37,9 @@
         internal const string TopMenu_EnableInfo = "Tools/Modular Avatar/Show Modular Avatar Information";
         internal const int TopMenu_EnableInfoOrder = 101;
 
+        internal const string TopMenu_CheckOutfitDrop = "Tools/Modular Avatar/Check Outfit Drop";
+        internal const int TopMenu_CheckOutfitDropOrder = 102;
+
         // <separator>
         
         internal const string TopMenu_ManualBakeAvatar = "Tools/Modular Avatar/Manual Bake Avatar";


### PR DESCRIPTION
related to #1573, #168

Setup Outfitを実行し忘れる問題への対処を追加します。

Setup Outfit実行可能かつ、MA設定済みでないPrefabがアバターにD&Dにより配置された際に、Setup Outfitを行うかどうかを聞くEditorWindowを自動で開くようにします。MA設定済みを理由として処理がスキップする際にはその旨がSceneViewに通知されるようしています。

とりあえずは動きますが、デフォルトで有効にするかどうかやEditorWindow内に対する詳細設定の追加、UIの細部など、詳細は詰めていないのでDraftです。筋が良い対処方かどうかという話もあるので、このPRが受け入れられる可能性があるかをお聞きしたいです。

<img width="624" height="333" alt="image" src="https://github.com/user-attachments/assets/6e651e1a-0a5d-44f0-9045-40d18e6b4d47" />
