### PR TITLE
fix: default value could be set to zero for menu item params

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1826] `MA Menu Item` のパラメーターが `MA Parameters` で制御される場合、値がゼロになるケースがある問題を修正
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1826] Fixed an issue where `MA Menu Item`s whose parameter is defined in a `MA Parameters` component could end up
+  with a value of zero.
 
 ### Changed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -11,6 +11,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 ### Added
 
 ### Fixed
+- [#1826] `MA Menu Item` のパラメーターが `MA Parameters` で制御される場合、値がゼロになるケースがある問題を修正
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#1826] Fixed an issue where `MA Menu Item`s whose parameter is defined in a `MA Parameters` component could end up
+  with a value of zero.
 
 ### Changed
 

--- a/Editor/ReactiveObjects/ParameterAssignerPass.cs
+++ b/Editor/ReactiveObjects/ParameterAssignerPass.cs
@@ -94,7 +94,7 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 // Assign automatic values first
                 int? defaultValue = null;
-                if (declaredParams.TryGetValue(paramName, out var p))
+                if (declaredParams.TryGetValue(paramName, out var p) && !Mathf.Approximately(0, p.defaultValue))
                 {
                     defaultValue = (int) p.defaultValue;
                 }


### PR DESCRIPTION
When a menu item parameter is set to automatic value with isDefault ON, but the parameter is controlled by a parent MA Parameters with a default of zero, we would previously set the menu item value to zero. This breaks the menu item as it's not possible to turn this menu item "off", as it just sets the parameter back to zero.

This change adjusts this logic to ignore the MA Parameters default value if it is zero; this then means we'll assign values starting at 1.
