### PR TITLE
Unity 6.3 made the default true,true system under an enum

### DIFF
--- a/Editor/Inspector/MaterialSwap/MatSwapEditor.cs
+++ b/Editor/Inspector/MaterialSwap/MatSwapEditor.cs
@@ -99,7 +99,11 @@ namespace nadena.dev.modular_avatar.core.editor
                         fromProperty.serializedObject.ApplyModifiedProperties();
                     });
                 }
+#if UNITY_6000_3_OR_NEWER
+                menu.DropDown(_fromField.worldBound, _fromField,DropdownMenuSizeMode.Auto);
+#else
                 menu.DropDown(_fromField.worldBound, _fromField);
+#endif
             };
         }
 


### PR DESCRIPTION
Adding this fixes compile in Unity 6.3, I found no other issues with the current build of 1.16.0-alpha.0