### PR TITLE
fix: mesh settings causes SMRs with no bones to move to an incorrect position

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1916] `Mesh Settings` の配下にボーン未設定の `Skinned Mesh Renderer` があると位置がズレる問題を修正
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1916] Fixed an issue where a `Skinned Mesh Renderer` under a `Mesh Settings` with no bone weights would potentially
+  end up in the wrong position.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -12,6 +12,8 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 
 ### Fixed
 
+- [#1916] `Mesh Settings` の配下にボーン未設定の `Skinned Mesh Renderer` があると位置がズレる問題を修正
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1916] Fixed an issue where a `Skinned Mesh Renderer` under a `Mesh Settings` with no bone weights would potentially
+  end up in the wrong position.
+
 ### Changed
 
 ### Removed

--- a/Editor/MeshSettingsPass.cs
+++ b/Editor/MeshSettingsPass.cs
@@ -141,10 +141,11 @@ namespace nadena.dev.modular_avatar.core.editor
                 {
                     Mesh newMesh = Object.Instantiate(smr.sharedMesh);
                     smr.sharedMesh = newMesh;
-                    smr.bones = new Transform[] { smr.transform };
+                    var originalTransform = smr.rootBone == null ? smr.transform : smr.rootBone;
+                    smr.bones = new[] { originalTransform };
                     smr.rootBone = smr.transform;
                     smr.sharedMesh.boneWeights = Enumerable.Repeat(new BoneWeight() { boneIndex0 = 0, weight0 = 1 }, newMesh.vertexCount).ToArray();
-                    smr.sharedMesh.bindposes = new Matrix4x4[] { smr.transform.worldToLocalMatrix * smr.transform.localToWorldMatrix };
+                    smr.sharedMesh.bindposes = new[] { Matrix4x4.identity };
 
                     if (newMesh) context.SaveAsset(newMesh);
                 }


### PR DESCRIPTION
Closes: #1883
