### PR TITLE
Add parameter detail in MA Infomation

### DIFF
--- a/Editor/Localization/en-US.json
+++ b/Editor/Localization/en-US.json
@@ -302,6 +302,8 @@
   "ma_info.param_usage_ui.free_space": "Unused parameter space ({0} bits)",
   "ma_info.param_usage_ui.exceeded_space": "Excess parameters ({0} bits)",
   "ma_info.param_usage_ui.bits_template": "{0} ({1} bits)",
+  "ma_info.param_usege_ui.parameter_type":  "type : {0} ({1} bits)",
+  "ma_info.param_usage_ui.is_name_deferred": "Auto rename : {0}",
   "ma_info.param_usage_ui.no_data": "[ NO DATA ]",
   "reactive_object.inverse": "Inverse Condition",
   "reactive_object.mesh_cutter.object": "Target Renderer",

--- a/Editor/Localization/ja-JP.json
+++ b/Editor/Localization/ja-JP.json
@@ -297,6 +297,8 @@
   "ma_info.param_usage_ui.free_space": "未使用領域 ({0} 個のビット)",
   "ma_info.param_usage_ui.exceeded_space": "超過分 ({0} 個のビット)",
   "ma_info.param_usage_ui.bits_template": "{0} ({1} 個のビットを使用中)",
+  "ma_info.param_usege_ui.parameter_type":  "タイプ : {0} ({1} ビット)", 
+  "ma_info.param_usage_ui.is_name_deferred": "自動リネーム : {0}",
   "ma_info.param_usage_ui.no_data": "[ NO DATA ]",
   "reactive_object.inverse": "条件を反転",
   "reactive_object.mesh_cutter.object": "対象のレンダラー",

--- a/Editor/Localization/ko-KR.json
+++ b/Editor/Localization/ko-KR.json
@@ -296,6 +296,8 @@
   "ma_info.param_usage_ui.free_space": "사용 가능 영역 ({0} 비트)",
   "ma_info.param_usage_ui.exceeded_space": "초과 영역 ({0} 비트)",
   "ma_info.param_usage_ui.bits_template": "{0} ({1} 비트 사용 중)",
+  "ma_info.param_usege_ui.parameter_type":  "type : {0} ({1} bits)",
+  "ma_info.param_usage_ui.is_name_deferred": "Auto rename : {0}",
   "ma_info.param_usage_ui.no_data": "[ 데이터 없음 ]",
   "reactive_object.inverse": "조건 반전",
   "reactive_object.mesh_cutter.object": "대상 렌더러",

--- a/Editor/Localization/zh-Hans.json
+++ b/Editor/Localization/zh-Hans.json
@@ -263,6 +263,8 @@
   "ma_info.param_usage_ui.other_objects": "此 Avatar 中的其他东西",
   "ma_info.param_usage_ui.free_space": "未使用的参数 ({0} bits)",
   "ma_info.param_usage_ui.bits_template": "{0} ({1} bits)",
+  "ma_info.param_usege_ui.parameter_type":  "type : {0} ({1} bits)",
+  "ma_info.param_usage_ui.is_name_deferred": "Auto rename : {0}",
   "ma_info.param_usage_ui.no_data": "【无信息】",
   "reactive_object.inverse": "反转条件",
   "reactive_object.delete-mesh-by-mask.material-index": "材质槽",

--- a/Editor/Localization/zh-Hant.json
+++ b/Editor/Localization/zh-Hant.json
@@ -281,6 +281,8 @@
   "ma_info.param_usage_ui.free_space": "未使用的參數空間 ({0} bits)",
   "ma_info.param_usage_ui.exceeded_space": "額外參數（{0} bits）",
   "ma_info.param_usage_ui.bits_template": "{0} ({1} bits)",
+  "ma_info.param_usege_ui.parameter_type":  "type : {0} ({1} bits)",
+  "ma_info.param_usage_ui.is_name_deferred": "Auto rename : {0}",
   "ma_info.param_usage_ui.no_data": "【無資訊】",
   "reactive_object.inverse": "反轉條件",
   "reactive_object.mesh_cutter.object": "目標 Renderer",

--- a/Editor/ParamsUsage/MAParametersIntrospection.cs
+++ b/Editor/ParamsUsage/MAParametersIntrospection.cs
@@ -28,6 +28,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
             var hidden = false;
             var name = _component.Control?.parameter?.name;
+            var isAutoName = string.IsNullOrWhiteSpace(name);
             if (string.IsNullOrWhiteSpace(name))
             {
                 name = $"__MA/AutoParam/{_component.gameObject.name}${_component.GetInstanceID()}";
@@ -37,7 +38,7 @@ namespace nadena.dev.modular_avatar.core.editor
             yield return new ProvidedParameter(
                 name,
                 ParameterNamespace.Animator,
-                _component, PluginDefinition.Instance, _component.AnimatorControllerParameterType)
+                _component, PluginDefinition.Instance, _component.AnimatorControllerParameterType, isAutoName)
             {
                 ExpandTypeOnConflict = true,
                 WantSynced = _component.isSynced,
@@ -85,7 +86,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 return new ProvidedParameter(
                     p.nameOrPrefix,
                     p.isPrefix ? ParameterNamespace.PhysBonesPrefix : ParameterNamespace.Animator,
-                    _component, PluginDefinition.Instance, paramType)
+                    _component, PluginDefinition.Instance, paramType, p.internalParameter)
                 {
                     IsAnimatorOnly = animatorOnly,
                     WantSynced = !p.localOnly && !animatorOnly,

--- a/Editor/ParamsUsage/ParamsUsage.uss
+++ b/Editor/ParamsUsage/ParamsUsage.uss
@@ -20,15 +20,21 @@
     margin-bottom: 12px;
 }
 
+LogoImage {
+    flex-shrink: 0;
+}
+
 #Footer {
     margin-left: 15px;
     margin-right: 15px;
+    flex-shrink: 0;
 }
 
 #UsageBox {
     height: 16px;
     flex-direction: row;
     margin-bottom: 8px;
+    flex-shrink: 0;
 }
 
 #UsageBox VisualElement {
@@ -50,6 +56,33 @@
 
 .Entry {
     flex-direction: row;
+}
+
+.Entry .ParameterFoldout {
+    flex-grow: 1;
+}
+
+.Entry .ParameterFoldout .unity-foldout__toggle {
+    margin: 0;
+}
+
+.Entry .ParameterFoldout .unity-foldout__toggle .unity-foldout__text {
+    padding-top: 0;
+    margin-left: 0;
+}
+
+.Entry .ParameterFoldout .ParameterBox {
+    padding: 5px;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.Entry .ParameterFoldout .ParameterBox .ParameterName {
+    -unity-font-style: bold;
+}
+
+.Entry .ParameterFoldout .ParameterBox .ParameterDetails {
+    margin-left: 5px;
 }
 
 .IconOuter {

--- a/Editor/ParamsUsage/ParamsUsage.uxml
+++ b/Editor/ParamsUsage/ParamsUsage.uxml
@@ -12,7 +12,7 @@
                 <ui:VisualElement name="UnusedSpace" style="width: auto; background-color: #eeeeee; flex-grow: 1;"/>
             </ui:VisualElement>
 
-            <ui:VisualElement name="Legend">
+            <ui:ScrollView name="Legend">
                 <ui:VisualElement class="retained">
                     <ui:VisualElement class="Entry" name="OtherObjects" style="display: none">
                         <ui:VisualElement class="IconOuter">
@@ -31,7 +31,7 @@
                     </ui:VisualElement>
                 </ui:VisualElement>
 
-            </ui:VisualElement>
+            </ui:ScrollView>
 
             <ui:VisualElement name="Exceeded">
             </ui:VisualElement>

--- a/Editor/ParamsUsage/ParamsUsageWindow.cs
+++ b/Editor/ParamsUsage/ParamsUsageWindow.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using nadena.dev.modular_avatar.ui;
 using nadena.dev.ndmf;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 using VRC.SDK3.Avatars.ScriptableObjects;
@@ -181,16 +182,22 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 outerbox.RemoveFromClassList("no-data");
             }
+            
+            var parameters = ParameterInfo.ForUI.GetParametersForObject(target)
+                .Where(p => p.BitUsage > 0)
+                .ToArray();
 
-            var orderedPlugins = ParameterInfo.ForUI.GetParametersForObject(target)
+            var orderedPlugins = parameters
                 .GroupBy(p => p.Plugin)
                 .Select(group => (group.Key, group.Sum(p => p.BitUsage)))
-                .Where((kv, index) => kv.Item2 > 0)
                 .OrderBy(group => group.Key.DisplayName)
                 .ToList();
 
+            var parameterLookup = parameters
+                .ToLookup(p => p.Plugin);
+
             var byPlugin = orderedPlugins
-                .Zip(Colors(), (kv, color) => (kv.Key.DisplayName, kv.Item2, kv.Key.ThemeColor ?? color))
+                .Zip(Colors(), (kv, color) => (kv.Key.DisplayName, kv.Item2, kv.Key.ThemeColor ?? color, parameterLookup[kv.Key]))
                 .ToList();
 
             int totalUsage = byPlugin.Sum(kv => kv.Item2);
@@ -206,17 +213,17 @@ namespace nadena.dev.modular_avatar.core.editor
             if (avatarTotalUsage > totalUsage)
             {
                 byPlugin.Add((Localization.S("ma_info.param_usage_ui.other_objects"), avatarTotalUsage - totalUsage,
-                    Color.gray));
+                    Color.gray, null));
             }
 
             var bits_template = Localization.S("ma_info.param_usage_ui.bits_template");
             byPlugin = byPlugin.Select((tuple, _) =>
-                (string.Format(bits_template, tuple.Item1, tuple.Item2), tuple.Item2, tuple.Item3)).ToList();
+                (string.Format(bits_template, tuple.Item1, tuple.Item2), tuple.Item2, tuple.Item3, tuple.Item4)).ToList();
 
             if (freeSpace > 0)
             {
                 var free_space_label = Localization.S("ma_info.param_usage_ui.free_space");
-                byPlugin.Add((string.Format(free_space_label, freeSpace), freeSpace, Color.white));
+                byPlugin.Add((string.Format(free_space_label, freeSpace), freeSpace, Color.white, null));
             }
 
             if (freeSpace < 0)
@@ -243,8 +250,11 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 child.RemoveFromHierarchy();
             }
-
-            foreach (var (label, usage, color) in byPlugin)
+            
+            var parameter_type_template = Localization.S("ma_info.param_usege_ui.parameter_type");
+            var parameter_is_name_deferred_template = Localization.S("ma_info.param_usage_ui.is_name_deferred");
+            
+            foreach (var (label, usage, color, providedParameters) in byPlugin)
             {
                 var colorBar = new VisualElement();
                 colorBar.style.backgroundColor = color;
@@ -266,9 +276,39 @@ namespace nadena.dev.modular_avatar.core.editor
                 icon_outer.Add(icon_inner);
                 icon_inner.style.backgroundColor = color;
 
-                var pluginLabel = new Label(label);
-                entry.Add(pluginLabel);
+                if (providedParameters != null) {
+                    var pluginFoldout = new Foldout {
+                        text = label,
+                        value = false
+                    };
+                    
+                    pluginFoldout.AddToClassList("ParameterFoldout");
+                    
+                    foreach (ProvidedParameter providedParameter in providedParameters) {
+                        var box = new Box();
+                        box.AddToClassList("ParameterBox");
+                        box.AddToClassList("unity-help-box");
+                        pluginFoldout.Add(box);
+                        
+                        var parameterNameLabel = new Label(providedParameter.EffectiveName);
+                        parameterNameLabel.AddToClassList("ParameterName");
+                        box.Add(parameterNameLabel);
 
+                        var details = new VisualElement();
+                        details.AddToClassList("ParameterDetails");
+                        box.Add(details);
+                        var sourceField = new ObjectField {value = providedParameter.Source};
+                        sourceField.SetEnabled(false);
+                        details.Add(sourceField);
+                        details.Add(new Label(string.Format(parameter_type_template, providedParameter.ParameterType, providedParameter.BitUsage)));
+                        details.Add(new Label(string.Format(parameter_is_name_deferred_template, providedParameter.IsNameDeferred)));
+                    }
+                    entry.Add(pluginFoldout);
+                } else {
+                    var pluginLabel = new Label(label);
+                    entry.Add(pluginLabel);
+                }
+                
                 entry.style.borderBottomColor = color;
                 entry.style.borderTopColor = color;
                 entry.style.borderLeftColor = color;


### PR DESCRIPTION
#2002 
<img width="616" height="428" alt="image" src="https://github.com/user-attachments/assets/8c813d4a-8de3-4f82-8bb9-f33a1f1d3444" />

`MA Infomation` に詳細なパラメータの情報を表示する機能を追加しました。
デフォルトではFlodoutで閉じています。

展開すると
- パラメータ名
- パラメータが定義されたコンポーネント
- パラメータタイプ (使用bits)
- 自動リネームの有効無効

が表示されます。

こちらの実装にあたって必要なパラメータを `ProvidedParameter` に追加しています。
https://github.com/bdunderscore/ndmf/pull/805

