### PR TITLE
Add Unity 6000 compatibility

### DIFF
--- a/Editor/CreateBlendTree.cs
+++ b/Editor/CreateBlendTree.cs
@@ -12,17 +12,28 @@ namespace nadena.dev.modular_avatar.core.editor
         static void CreateNewBlendTree()
         {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+#if UNITY_6000_4_OR_NEWER
+               EntityId.None,
+#else
                0,
+#endif
                Editor.CreateInstance<DoCreateBlendTree>(),
                "New BlendTree.asset",
                EditorGUIUtility.IconContent("BlendTree Icon").image as Texture2D,
                null);
         }
 
+        #if UNITY_6000_4_OR_NEWER
+        class DoCreateBlendTree : AssetCreationEndAction
+        {
+            public override void Action(EntityId instanceId, string pathName, string resourceFile)
+            {
+#else
         class DoCreateBlendTree : EndNameEditAction
         {
             public override void Action(int instanceId, string pathName, string resourceFile)
             {
+#endif
                 BlendTree blendTree = new BlendTree { name = Path.GetFileNameWithoutExtension(pathName) };
                 AssetDatabase.CreateAsset(blendTree, pathName);
                 Selection.activeObject = blendTree;

--- a/Editor/Inspector/BlendshapeSelectTreeView.cs
+++ b/Editor/Inspector/BlendshapeSelectTreeView.cs
@@ -7,6 +7,16 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_2_OR_NEWER
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#else
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState;
+#endif
+
 namespace nadena.dev.modular_avatar.core.editor
 {
     internal class BlendshapeSelectWindow : EditorWindow
@@ -39,9 +49,9 @@ namespace nadena.dev.modular_avatar.core.editor
                 _searchField = new SearchField();
                 if (SingleMesh != null)
                 {
-                    _tree = new BlendshapeTree(SingleMesh, new TreeViewState());
+                    _tree = new BlendshapeTree(SingleMesh, new TreeViewStateCompat());
                 } else if (AvatarRoot != null) {
-                    _tree = new BlendshapeTree(AvatarRoot, new TreeViewState());
+                    _tree = new BlendshapeTree(AvatarRoot, new TreeViewStateCompat());
                 }
                 else
                 {
@@ -78,9 +88,9 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 
-    internal class BlendshapeTree : TreeView
+    internal class BlendshapeTree : TreeViewCompat
     {
-        internal class OfferItem : TreeViewItem
+        internal class OfferItem : TreeViewItemCompat
         {
             // Initialized when the item is created in CreateBlendshapes()
             public BlendshapeBinding binding = default!;
@@ -96,17 +106,17 @@ namespace nadena.dev.modular_avatar.core.editor
         internal Action<BlendshapeBinding>? OfferSingleClick;
         internal Action<IList<BlendshapeBinding>>? OfferMultipleBindings;
 
-        public BlendshapeTree(GameObject avatarRoot, TreeViewState state) : base(state)
+        public BlendshapeTree(GameObject avatarRoot, TreeViewStateCompat state) : base(state)
         {
             this._avatarRoot = avatarRoot;
         }
         
-        public BlendshapeTree(Mesh mesh, TreeViewState state) : base(state)
+        public BlendshapeTree(Mesh mesh, TreeViewStateCompat state) : base(state)
         {
             this._singleMesh = mesh;
         }
 
-        public BlendshapeTree(GameObject avatarRoot, TreeViewState state, MultiColumnHeader multiColumnHeader) : base(
+        public BlendshapeTree(GameObject avatarRoot, TreeViewStateCompat state, MultiColumnHeader multiColumnHeader) : base(
             state, multiColumnHeader)
         {
             this._avatarRoot = avatarRoot;
@@ -160,7 +170,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        protected override bool CanMultiSelect(TreeViewItem item)
+        protected override bool CanMultiSelect(TreeViewItemCompat item)
         {
             return item is OfferItem;
         }
@@ -212,13 +222,13 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        protected override TreeViewItem BuildRoot()
+        protected override TreeViewItemCompat BuildRoot()
         {
-            var root = new TreeViewItem {id = 0, depth = -1, displayName = "Root"};
+            var root = new TreeViewItemCompat {id = 0, depth = -1, displayName = "Root"};
             _candidateBindings = new List<BlendshapeBinding?>();
             _candidateBindings.Add(null);
 
-            var allItems = new List<TreeViewItem>();
+            var allItems = new List<TreeViewItemCompat>();
 
             int createdDepth = 0;
             List<string> ObjectDisplayNames = new List<string>();
@@ -237,7 +247,7 @@ namespace nadena.dev.modular_avatar.core.editor
             return root;
         }
 
-        private void WalkTree(GameObject node, List<TreeViewItem> items, List<string> objectDisplayNames,
+        private void WalkTree(GameObject node, List<TreeViewItemCompat> items, List<string> objectDisplayNames,
             ref int createdDepth)
         {
             objectDisplayNames.Add(node.name);
@@ -247,7 +257,7 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 while (createdDepth < objectDisplayNames.Count)
                 {
-                    items.Add(new TreeViewItem
+                    items.Add(new TreeViewItemCompat
                     {
                         id = _candidateBindings.Count, depth = createdDepth,
                         displayName = objectDisplayNames[createdDepth]
@@ -268,9 +278,9 @@ namespace nadena.dev.modular_avatar.core.editor
             createdDepth = Math.Min(createdDepth, objectDisplayNames.Count);
         }
 
-        private void CreateBlendshapes(SkinnedMeshRenderer smr, List<TreeViewItem> items, ref int createdDepth)
+        private void CreateBlendshapes(SkinnedMeshRenderer smr, List<TreeViewItemCompat> items, ref int createdDepth)
         {
-            items.Add(new TreeViewItem
+            items.Add(new TreeViewItemCompat
                 {id = _candidateBindings.Count, depth = createdDepth, displayName = "BlendShapes"});
             _candidateBindings.Add(null);
             createdDepth++;
@@ -283,7 +293,7 @@ namespace nadena.dev.modular_avatar.core.editor
             createdDepth--;
         }
 
-        private void CreateBlendshapes(List<TreeViewItem> items, Mesh mesh, string? path, int createdDepth)
+        private void CreateBlendshapes(List<TreeViewItemCompat> items, Mesh mesh, string? path, int createdDepth)
         {
             List<BlendshapeBinding> bindings = Enumerable.Range(0, mesh.blendShapeCount)
                 .Select(n =>

--- a/Editor/Inspector/Menu/AvMenuTreeView.cs
+++ b/Editor/Inspector/Menu/AvMenuTreeView.cs
@@ -10,6 +10,16 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
+
+#if UNITY_6000_2_OR_NEWER
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#else
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState;
+#endif
 using VRC.SDK3.Avatars.ScriptableObjects;
 using static nadena.dev.modular_avatar.core.editor.Localization;
 
@@ -38,7 +48,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         private void Awake()
         {
-            _treeView = new AvMenuTreeView(new TreeViewState());
+            _treeView = new AvMenuTreeView(new TreeViewStateCompat());
             _treeView.OnSelect = (menu) => OnMenuSelected.Invoke(menu);
             _treeView.OnDoubleclickSelect = Close;
             _cacheIndex = -1;
@@ -85,7 +95,7 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 
-    class AvMenuTreeView : TreeView
+    class AvMenuTreeView : TreeViewCompat
     {
         private VRCAvatarDescriptor _avatar;
 
@@ -120,7 +130,7 @@ namespace nadena.dev.modular_avatar.core.editor
         private VirtualMenu _menuTree;
         private Stack<object> _visitedMenuStack = new Stack<object>();
 
-        public AvMenuTreeView(TreeViewState state) : base(state)
+        public AvMenuTreeView(TreeViewStateCompat state) : base(state)
         {
         }
 
@@ -149,7 +159,7 @@ namespace nadena.dev.modular_avatar.core.editor
             OnDoubleclickSelect.Invoke();
         }
 
-        protected override TreeViewItem BuildRoot()
+        protected override TreeViewItemCompat BuildRoot()
         {
             _nodeKeys.Clear();
             _visitedMenuStack.Clear();
@@ -168,10 +178,10 @@ namespace nadena.dev.modular_avatar.core.editor
                 rootName = $"({menu.name})";
             }
 
-            var root = new TreeViewItem(-1, -1, "<root>");
-            List<TreeViewItem> treeItems = new List<TreeViewItem>
+            var root = new TreeViewItemCompat(-1, -1, "<root>");
+            List<TreeViewItemCompat> treeItems = new List<TreeViewItemCompat>
             {
-                new TreeViewItem
+                new TreeViewItemCompat
                 {
                     id = 0,
                     depth = 0,
@@ -208,7 +218,7 @@ namespace nadena.dev.modular_avatar.core.editor
             return menuTree.RootMenuKey;
         }
 
-        private void TraverseMenu(int depth, List<TreeViewItem> items, VirtualMenuNode node)
+        private void TraverseMenu(int depth, List<TreeViewItemCompat> items, VirtualMenuNode node)
         {
             IEnumerable<VirtualControl> children = node.Controls
                 .Where(control => control.type == VRCExpressionsMenu.Control.ControlType.SubMenu &&
@@ -219,7 +229,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 string displayName = child.name;
 
                 items.Add(
-                    new TreeViewItem
+                    new TreeViewItemCompat
                     {
                         id = items.Count,
                         depth = depth,

--- a/Editor/Inspector/Menu/ParameterField.cs
+++ b/Editor/Inspector/Menu/ParameterField.cs
@@ -6,6 +6,16 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
+
+#if UNITY_6000_2_OR_NEWER
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#else
+using TreeViewCompat = UnityEditor.IMGUI.Controls.TreeView;
+using TreeViewItemCompat = UnityEditor.IMGUI.Controls.TreeViewItem;
+using TreeViewStateCompat = UnityEditor.IMGUI.Controls.TreeViewState;
+#endif
 using static nadena.dev.modular_avatar.core.editor.Localization;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -122,7 +132,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
                 if (_tree == null)
                 {
-                    _tree = new ParameterTree(new TreeViewState(), _target);
+                    _tree = new ParameterTree(new TreeViewStateCompat(), _target);
                     _tree.OnSelect = (s) =>
                     {
                         _prop.stringValue = s;
@@ -150,24 +160,24 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        private class ParameterTree : TreeView
+        private class ParameterTree : TreeViewCompat
         {
             private List<string> _items;
             public Action<string> OnSelect, OnCommit;
 
             private GameObject _obj;
 
-            private class SourceItem : TreeViewItem
+            private class SourceItem : TreeViewItemCompat
             {
                 public GameObject source;
             }
 
-            private class ParamItem : TreeViewItem
+            private class ParamItem : TreeViewItemCompat
             {
                 public GameObject source;
             }
 
-            public ParameterTree(TreeViewState state, GameObject obj) : base(state)
+            public ParameterTree(TreeViewStateCompat state, GameObject obj) : base(state)
             {
                 _obj = obj;
             }
@@ -224,13 +234,13 @@ namespace nadena.dev.modular_avatar.core.editor
                 }
             }
 
-            protected override TreeViewItem BuildRoot()
+            protected override TreeViewItemCompat BuildRoot()
             {
-                List<TreeViewItem> treeItems = new List<TreeViewItem>();
+                List<TreeViewItemCompat> treeItems = new List<TreeViewItemCompat>();
                 _items = new List<string>();
 
                 _items.Add("");
-                var root = new TreeViewItem {id = 0, depth = -1, displayName = "Root"};
+                var root = new TreeViewItemCompat {id = 0, depth = -1, displayName = "Root"};
 
                 GameObject priorNode = null;
 

--- a/Editor/ObjectReferenceFixer.cs
+++ b/Editor/ObjectReferenceFixer.cs
@@ -5,15 +5,21 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 
+#if UNITY_6000_4_OR_NEWER
+using ObjectId = UnityEngine.EntityId;
+#else
+using ObjectId = System.Int32;
+#endif
+
 namespace nadena.dev.modular_avatar.core
 {
     public static class ObjectReferenceFixer
     {
         private static ComputeContext _context;
 
-        private static int? _lastStage;
+        private static ObjectId? _lastStage;
 
-        private static int? GetCurrentContentsRootId(out GameObject contentsRoot)
+        private static ObjectId? GetCurrentContentsRootId(out GameObject contentsRoot)
         {
             contentsRoot = null;
 
@@ -22,7 +28,11 @@ namespace nadena.dev.modular_avatar.core
 
             contentsRoot = stage.prefabContentsRoot;
 
+            #if UNITY_6000_4_OR_NEWER
+            return stage.prefabContentsRoot.GetEntityId();
+#else
             return stage.prefabContentsRoot.GetInstanceID();
+#endif
         }
         
         [InitializeOnLoadMethod]

--- a/Editor/ParamsUsage/MAParametersIntrospection.cs
+++ b/Editor/ParamsUsage/MAParametersIntrospection.cs
@@ -30,7 +30,11 @@ namespace nadena.dev.modular_avatar.core.editor
             var name = _component.Control?.parameter?.name;
             if (string.IsNullOrWhiteSpace(name))
             {
+                #if UNITY_6000_4_OR_NEWER
+                name = $"__MA/AutoParam/{_component.gameObject.name}${_component.GetEntityId()}";
+#else
                 name = $"__MA/AutoParam/{_component.gameObject.name}${_component.GetInstanceID()}";
+#endif
                 hidden = true;
             }
 
@@ -113,7 +117,11 @@ namespace nadena.dev.modular_avatar.core.editor
                     }
                     else
                     {
+                        #if UNITY_6000_4_OR_NEWER
+                        remapTo = p.nameOrPrefix + "$" + _component.GetEntityId();
+#else
                         remapTo = p.nameOrPrefix + "$" + _component.GetInstanceID();
+#endif
                     }
                 }
                 else if (string.IsNullOrEmpty(p.remapTo))

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.LocateReactions.cs
@@ -27,7 +27,11 @@ namespace nadena.dev.modular_avatar.core.editor
             }
             else
             {
+                #if UNITY_6000_4_OR_NEWER
+                var param = "__ActiveSelfProxy/" + obj.GetEntityId();
+#else
                 var param = "__ActiveSelfProxy/" + obj.GetInstanceID();
+#endif
                 _simulationInitialStates[param] = obj.activeSelf ? 1.0f : 0.0f;
                 return param;
             }

--- a/Editor/ReactiveObjects/MeshFiltering/VertexFilterByMask.cs
+++ b/Editor/ReactiveObjects/MeshFiltering/VertexFilterByMask.cs
@@ -337,7 +337,11 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public override string ToString()
         {
+#if UNITY_6000_4_OR_NEWER
+            return $"{_materialIndex}_{(_maskTexture == null ? EntityId.None : _maskTexture.GetEntityId())}_{DeleteMode}_{_selectionMode}_uv{_uvChannel}";
+#else
             return $"{_materialIndex}_{_maskTexture?.GetInstanceID()}_{DeleteMode}_{_selectionMode}_uv{_uvChannel}";
+#endif
         }
     }
 }

--- a/Editor/ReactiveObjects/ParameterAssignerPass.cs
+++ b/Editor/ReactiveObjects/ParameterAssignerPass.cs
@@ -218,7 +218,14 @@ namespace nadena.dev.modular_avatar.core.editor
             if (mami?.Control != null && isSimulation && ShouldAssignParametersToMami(mami))
             {
                 paramName = mami.Control?.parameter?.name;
-                if (string.IsNullOrEmpty(paramName)) paramName = "___AutoProp/" + mami.GetInstanceID();
+                if (string.IsNullOrEmpty(paramName))
+                {
+#if UNITY_6000_4_OR_NEWER
+                    paramName = "___AutoProp/" + mami.GetEntityId();
+#else
+                    paramName = "___AutoProp/" + mami.GetInstanceID();
+#endif
+                }
 
                 if (simulationInitialStates != null)
                 {

--- a/Editor/ReactiveObjects/Simulator/ROSimulator.cs
+++ b/Editor/ReactiveObjects/Simulator/ROSimulator.cs
@@ -11,6 +11,12 @@ using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
+#if UNITY_6000_4_OR_NEWER
+using ObjectId = UnityEngine.EntityId;
+#else
+using ObjectId = System.Int32;
+#endif
+
 namespace nadena.dev.modular_avatar.core.editor.Simulator
 {
     internal class ROSimulator : EditorWindow, IHasCustomMenu
@@ -105,7 +111,7 @@ namespace nadena.dev.modular_avatar.core.editor.Simulator
         private GUIStyle lockButtonStyle;
         private bool locked, is_enabled;
 
-        private Dictionary<(int, string), bool> foldoutState = new();
+        private Dictionary<(ObjectId, string), bool> foldoutState = new();
         private Button _btn_clear;
 
         private bool _refreshPending;
@@ -393,7 +399,11 @@ namespace nadena.dev.modular_avatar.core.editor.Simulator
 
                 var propGroup = new Foldout();
                 propGroup.text = targetProp.TargetObject.GetType() + "." + targetProp.PropertyName;
+                #if UNITY_6000_4_OR_NEWER
+                var foldoutStateKey = (shape.TargetProp.TargetObject?.GetEntityId() ?? EntityId.None, shape.TargetProp.PropertyName);
+#else
                 var foldoutStateKey = (shape.TargetProp.TargetObject?.GetInstanceID() ?? -1, shape.TargetProp.PropertyName);
+#endif
                 propGroup.RegisterValueChangedCallback(evt =>
                 {
                     foldoutState[foldoutStateKey] = evt.newValue;


### PR DESCRIPTION
# Reasons
- Unity 6000.5 now requires you to use the EntityID system.
- Anything using the InstanceID system no longer compiles in Unity 6000.5 for depreciation error.
# Notes
Did not want 1000 compiler flags, so went and add using alias, for things that change with the new version where possible.