### PR TITLE
fix: NullReferenceException when opening Reaction Debugger

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2079] Reaction Debugger を開いた際に、オーバーライド状態の初期化前に `NullReferenceException` が発生する問題を修正
 - [#2077] `Scale Adjuster` のプレビュー処理を高速化
 
 ### Changed

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2079] Fixed a `NullReferenceException` when opening the Reaction Debugger before its override state was initialized
 - [#2077] Improved performance of `Scale Adjuster` previews
 
 ### Changed

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -11,6 +11,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 ### Added
 
 ### Fixed
+- [#2079] Reaction Debugger を開いた際に、オーバーライド状態の初期化前に `NullReferenceException` が発生する問題を修正
 - [#2077] `Scale Adjuster` のプレビュー処理を高速化
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2079] Fixed a `NullReferenceException` when opening the Reaction Debugger before its override state was initialized
 - [#2077] Improved performance of `Scale Adjuster` previews
 
 ### Changed

--- a/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.cs
+++ b/Editor/ReactiveObjects/AnimationGeneration/ReactiveObjectAnalyzer.cs
@@ -270,8 +270,9 @@ namespace nadena.dev.modular_avatar.core.editor
             Dictionary<string, float> propStates = new();
             Dictionary<string, float> nextPropStates = new();
             int loopLimit = 5;
+            var forceOverrides = ForcePropertyOverrides ?? ImmutableDictionary<string, float>.Empty;
             
-            foreach (var kvp in ForcePropertyOverrides)
+            foreach (var kvp in forceOverrides)
             {
                 propStates[kvp.Key] = kvp.Value;
             }
@@ -324,7 +325,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     }
                 }
                 
-                foreach (var kvp in ForcePropertyOverrides)
+                foreach (var kvp in forceOverrides)
                 {
                     nextPropStates[kvp.Key] = kvp.Value;
                 }

--- a/Editor/ReactiveObjects/Simulator/ROSimulator.cs
+++ b/Editor/ReactiveObjects/Simulator/ROSimulator.cs
@@ -264,6 +264,12 @@ namespace nadena.dev.modular_avatar.core.editor.Simulator
                 return;
             }
 
+            // OpenDebugger can run before OnEnable's delayCall initializes these to Empty.
+            if (PropertyOverrides.Value == null)
+                PropertyOverrides.Value = ImmutableDictionary<string, float>.Empty;
+            if (MenuItemOverrides.Value == null)
+                MenuItemOverrides.Value = ImmutableDictionary<string, ModularAvatarMenuItem>.Empty;
+
             _btn_clear.SetEnabled(PropertyOverrides.Value?.IsEmpty == false || MenuItemOverrides.Value?.IsEmpty == false);
             
             e_debugInfo.style.display = DisplayStyle.Flex;


### PR DESCRIPTION
## Summary
- Opening the Reaction Debugger (`ROSimulator.OpenDebugger`) calls `RefreshUI()` immediately, while `PropertyOverrides` / `MenuItemOverrides` are only initialized to empty dictionaries in `OnEnable` via `EditorApplication.delayCall`.
- On first open (or after the window was disabled), those values are still `null`, so assigning them to `ForcePropertyOverrides` and iterating in `ResolveToggleInitialStates` throws `NullReferenceException`.
- Initialize empty override dictionaries in `RefreshUI` before analysis, and treat a null `ForcePropertyOverrides` as empty (consistent with `CachedAnalyze` / `ApplyInitialStateOverrides`).

## Reproduction
1. Ensure the Reaction Debugger window is closed (or after domain reload).
2. Select an avatar object with reactive components.
3. Open **Show Reaction Debugger** (inspector button or menu).
4. Observe `NullReferenceException` at `ReactiveObjectAnalyzer.ResolveToggleInitialStates`.

## Test plan
- [ ] Open Reaction Debugger on a fresh Editor session / after domain reload — no NRE
- [ ] Toggle simulator overrides and clear them — still works
- [ ] Close and reopen the debugger — still works
- [ ] Avatar with Object Toggles / Menu Items still analyzes correctly in the debugger