### PR TITLE
feat: VRCSDK 3.7.0 compile-time compatibility

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2090] VRCSDK 3.7.0 環境でコンパイルエラーになる問題
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2090] Compile error with VRCSDK 3.7.0
 
 ### Changed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -11,6 +11,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 ### Added
 
 ### Fixed
+- [#2090] VRCSDK 3.7.0 環境でコンパイルエラーになる問題
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2090] Compile error with VRCSDK 3.7.0
 
 ### Changed
 

--- a/Editor/WorldScaleObjectPass.cs
+++ b/Editor/WorldScaleObjectPass.cs
@@ -29,7 +29,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 {
 #if MA_VRCSDK3_AVATARS
                     var c = target.gameObject.AddComponent<VRCScaleConstraint>();
-                    c.Sources.Add(new VRCConstraintSource(fixedPrefab.transform, 1));
+                    c.Sources.Add(new VRCConstraintSource(fixedPrefab.transform, 1, Vector3.zero, Vector3.zero));
                     c.Locked = true;
                     c.IsActive = true;
 #else


### PR DESCRIPTION
I found there is compile error with SDK 3.7.0 when I'm testing my tool.

I don't know the version support policy in modular avatar, but I found several scripting defines for VRCSDK 3.7.0 or earlier so I created pull request