### PR TITLE
fix: incorrect preview ordering

### DIFF
--- a/CHANGELOG-PRERELEASE-jp.md
+++ b/CHANGELOG-PRERELEASE-jp.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2112] `Shape Changer` と併用する場合、 `Mesh Cutter` のプレビュー処理が実際の挙動と違っていた問題を修正
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2112] Mesh Cutter previews show incorrect results when used in combination with Shape Changer
 
 ### Changed
 

--- a/CHANGELOG-jp.md
+++ b/CHANGELOG-jp.md
@@ -11,6 +11,7 @@ Modular Avatarの主な変更点をこのファイルで記録しています。
 ### Added
 
 ### Fixed
+- [#2112] `Shape Changer` と併用する場合、 `Mesh Cutter` のプレビュー処理が実際の挙動と違っていた問題を修正
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#2112] Mesh Cutter previews show incorrect results when used in combination with Shape Changer
 
 ### Changed
 

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -86,7 +86,7 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                     seq.WithRequiredExtension(typeof(ReadablePropertyExtension), _s3 =>
                     {
                         seq.Run("Reactive Components", ctx => new ReactiveObjectPass(ctx).Execute())
-                            .PreviewingWith(new ShapeChangerPreview(), new MeshDeleterPreview(),
+                            .PreviewingWith(new MeshDeleterPreview(), new ShapeChangerPreview(),
                                 new ObjectSwitcherPreview(), new MaterialSetterPreview());
                     })
 ;


### PR DESCRIPTION
Previously, we applied shape changer before mesh deleter; this did not match the actual
runtime behavior, which computed the portion of the mesh to delete before applying shape
changer values.
